### PR TITLE
Remove undefined methods/variables from signature

### DIFF
--- a/lib/restful_resource/paginated_array.rb
+++ b/lib/restful_resource/paginated_array.rb
@@ -1,6 +1,6 @@
 module RestfulResource
   class PaginatedArray < Array
-    def initialize(original_array, previous_page_url: previous_page_url, next_page_url: next_page_url)
+    def initialize(original_array, previous_page_url: nil, next_page_url: nil)
       super(original_array)
 
       @previous_page_url = previous_page_url
@@ -17,7 +17,7 @@ module RestfulResource
 
     private
     def get_page_from_url(url)
-      return nil unless url
+      return unless url
       params = Rack::Utils.parse_query URI(url).query
       params['page'].to_i
     end


### PR DESCRIPTION
The constructor's signature implies that there is no need to pass
additional arguments except `original_array`.

However, the snippet below results in an error

```
RestfulResource::PaginatedArray.new([])
=> NameError: undefined local variable or method `previous_page_url' for []:RestfulResource::PaginatedArray
```

Assuming that we allow urls to be `nil`
https://github.com/carwow/restful_resource/blob/master/lib/restful_resource/paginated_array.rb#L20
we can default to optional params with `nil` default values