### PR TITLE
Allow client to pass a logger for requests

### DIFF
--- a/lib/restful_resource.rb
+++ b/lib/restful_resource.rb
@@ -5,6 +5,7 @@ require 'restclient'
 require 'active_support'
 require 'active_support/all'
 require_relative "restful_resource/version"
+require_relative 'restful_resource/null_logger'
 require_relative "restful_resource/paginated_array"
 require_relative "restful_resource/parameter_missing_error"
 require_relative "restful_resource/resource_id_missing_error"

--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -2,8 +2,10 @@ module RestfulResource
   class Base < OpenObject
     extend RestfulResource::Associations
 
-    def self.configure(base_url: nil, username: nil, password: nil)
+    def self.configure(base_url: nil, username: nil, password: nil, logger: NullLogger.new)
       @base_url = URI.parse(base_url)
+
+      RestClient.log = logger
 
       auth = nil
 
@@ -24,7 +26,8 @@ module RestfulResource
     end
 
     def self.where(params={})
-      response = http.get(collection_url(params))
+      url = collection_url(params)
+      response = http.get(url)
       self.paginate_response(response)
     end
 
@@ -40,7 +43,6 @@ module RestfulResource
 
     def self.put(id, data: {}, **params)
       url = member_url(id, params)
-
       response = http.put(url, data: data)
       self.new(parse_json(response.body))
     end

--- a/lib/restful_resource/null_logger.rb
+++ b/lib/restful_resource/null_logger.rb
@@ -1,0 +1,6 @@
+module RestfulResource
+  class NullLogger
+    def <<(*args)
+    end
+  end
+end

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = "0.8.29"
+  VERSION = "0.8.30"
 end

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -223,6 +223,34 @@ describe RestfulResource::Base do
     end
   end
 
+  describe 'logger' do
+    before do
+      RestfulResource::Base.configure(base_url: 'http://api.carwow.co.uk/')
+    end
+
+    context 'when no logger is passed' do
+      it 'defaults to NullLogger' do
+        expect(RestClient.log).to be_instance_of(RestfulResource::NullLogger)
+      end
+    end
+
+    context 'when a logger is passed' do
+      before do
+        RestfulResource::Base.configure(base_url: 'http://api.carwow.co.uk/', logger: my_logger)
+      end
+
+      after do
+        RestClient.log = RestfulResource::NullLogger.new
+      end
+
+      let(:my_logger) { double('logger') }
+
+      it 'uses that logger' do
+        expect(RestClient.log).to eq(my_logger)
+      end
+    end
+  end
+
   def response_with_page_information
     RestfulResource::Response.new(body: [{ id: 1, name: 'Golf'}, { id: 2, name: 'Polo' }].to_json,
                                  headers: { links: '<http://api.carwow.co.uk/makes/Volkswagen/models.json?page=6>;rel="last",<http://api.carwow.co.uk/makes/Volkswagen/models.json?page=2>;rel="next"'})


### PR DESCRIPTION
We are now allowing a client to pass a logger which will log the
requests via the RestClient.log

If nothing is passed, we default to a NullLogger object that serves as
an interface