### PR TITLE
Display request url in 503 error message

### DIFF
--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -26,7 +26,7 @@ module RestfulResource
 
     class ServiceUnavailable < HttpError
       def message
-        "HTTP 503: Service unavailable"
+        "HTTP 503: Service unavailable #{request.url}"
       end
     end
 

--- a/spec/restful_resource/http_client_errors_spec.rb
+++ b/spec/restful_resource/http_client_errors_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../spec_helper'
+
+describe RestfulResource::HttpClient::ServiceUnavailable do
+  let(:request) { instance_double(RestfulResource::Request, url: 'http://httpbin.org/status/503') }
+  let(:response) { Hash.new }
+  subject { described_class.new request, response  }
+
+  describe 'message' do
+    it 'includes the request url' do
+      expect(subject.message).to eq 'HTTP 503: Service unavailable http://httpbin.org/status/503'
+    end
+  end
+end


### PR DESCRIPTION
Add the request url into the error message for 503 errors

When 503 errors get raised it is helpful to know which url it relates to.
This makes it easier to see what request is actually failing

Related to: https://trello.com/c/SFGCyNLm/164-consolidate-503-exceptions
