### PR TITLE
Set a default timeout on all requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'pry'

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -50,7 +50,12 @@ module RestfulResource
         b.response :encoding
         b.use :gzip
 
-        b.adapter :net_http
+        b.adapter :excon,
+                  nonblock: true, # Always use non-blocking IO (for safe timeouts)
+                  persistent: true, # Re-use TCP connections
+                  connect_timeout: 2, # seconds
+                  read_timeout: 10, # seconds
+                  write_timeout: 2 # seconds
       end
     end
 

--- a/restful_resource.gemspec
+++ b/restful_resource.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "link_header"
   spec.add_dependency "activesupport"
   spec.add_dependency "rack"
+  spec.add_dependency "excon"
 end


### PR DESCRIPTION
* 2 seconds to connect and write
* 10 seconds to read (i.e. return the result)

Switches to Excon as the Faraday adapter, for safe timeouts (uses
IO.select instead of Timeout.timeout)