### PR TITLE
Fix client error bug and refactor tests

### DIFF
--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -3,8 +3,12 @@ module RestfulResource
     class HttpError < StandardError
       attr_reader :request, :response
 
-      def initialize(request, response)
-        @response = Response.new(body: response[:body], headers: response[:headers], status: response[:status])
+      def initialize(request, response = nil)
+        if response
+          @response = Response.new body: response[:body], headers: response[:headers], status: response[:status]
+        else
+          @response = Response.new
+        end
         @request = request
       end
     end
@@ -31,10 +35,6 @@ module RestfulResource
     end
 
     class ClientError < HttpError
-      def initalize(request)
-        super(request, {})
-      end
-
       def message
         "There was some client error"
       end
@@ -64,7 +64,7 @@ module RestfulResource
                   nonblock: true, # Always use non-blocking IO (for safe timeouts)
                   persistent: true, # Re-use TCP connections
                   connect_timeout: 2, # seconds
-                  read_timeout: 10, # seconds
+                  read_timeout: 20, # seconds
                   write_timeout: 2 # seconds
       end
     end

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end

--- a/spec/restful_resource/http_client_configuration_spec.rb
+++ b/spec/restful_resource/http_client_configuration_spec.rb
@@ -1,0 +1,93 @@
+require_relative '../spec_helper'
+
+describe RestfulResource::HttpClient do
+  def find_middleware(adapter, name)
+    adapter.builder.handlers.find {|m| m.name == name }
+
+    rescue
+      raise "Could not find Faraday middleware: #{name}"
+  end
+
+  def find_middleware_args(adapter, name)
+    find_middleware(adapter, name).instance_variable_get("@args").first
+
+    rescue
+      raise "Could not find args for Faraday middleware: #{name}"
+  end
+
+  describe 'Configuration' do
+    let(:connection) { described_class.new.instance_variable_get("@connection") }
+    let(:middleware) { connection.builder.handlers }
+
+    describe 'Builder configuration' do
+      it 'uses the excon adapter' do
+        expect(middleware).to include Faraday::Adapter::Excon
+      end
+
+      it 'url_encodes requests' do
+        expect(middleware).to include Faraday::Request::UrlEncoded
+      end
+
+      it 'raises on any error responses' do
+        expect(middleware).to include Faraday::Response::RaiseError
+      end
+
+      it 'uses utf-8 encoding' do
+        expect(middleware).to include Faraday::Encoding
+      end
+
+      it 'compresses requests' do
+        expect(middleware).to include FaradayMiddleware::Gzip
+      end
+
+      describe 'when provided a logger' do
+        let(:connection) { described_class.new(logger: logger).instance_variable_get("@connection") }
+        let(:logger) { Logger.new('/dev/null') }
+
+        it 'uses the logger middleware' do
+          expect(middleware).to include Faraday::Response::Logger
+        end
+
+        it 'uses that logger' do
+          expect(find_middleware_args(connection, 'Faraday::Response::Logger')).to eq logger
+        end
+      end
+
+      describe 'when provided a cache store' do
+        let(:connection) { described_class.new(cache_store: 'redis').instance_variable_get("@connection") }
+
+        it 'uses the cache_store middleware' do
+          expect(middleware).to include Faraday::HttpCache
+        end
+
+        it 'uses that cache_store' do
+          expect(find_middleware_args(connection, 'Faraday::HttpCache')).to include(store: 'redis')
+        end
+      end
+    end
+
+    describe 'Excon Adapter configuration' do
+      let(:config) { find_middleware_args connection, 'Faraday::Adapter::Excon' }
+    
+      it 'uses nonblock' do
+        expect(config[:nonblock]).to eq true
+      end
+
+      it 'uses a persistent connection' do
+        expect(config[:persistent]).to eq true
+      end
+
+      it 'has a connect_timeout of 2' do
+        expect(config[:connect_timeout]).to eq 2
+      end
+
+      it 'has a read_timeout of 10' do
+        expect(config[:read_timeout]).to eq 10
+      end
+
+      it 'has a write_timeout of 2' do
+        expect(config[:write_timeout]).to eq 2
+      end
+    end
+  end
+end

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -1,67 +1,145 @@
 require_relative '../spec_helper'
 
 describe RestfulResource::HttpClient do
-  describe 'Basic HTTP' do
-    before :each do
-      @http_client = RestfulResource::HttpClient.new
+  def faraday_connection
+    Faraday.new do |builder|
+      builder.request :url_encoded
+      builder.response :raise_error
+      builder.adapter :test do |stubs|
+        yield stubs if block_given?
+      end
     end
+  end
 
+  def http_client(connection)
+    described_class.new(connection: connection)
+  end
+
+  describe 'Basic HTTP' do
     it 'should execute get' do
-      response = @http_client.get('http://httpbin.org/get')
+      connection = faraday_connection do |stubs|
+        stubs.get('http://httpbin.org/get') { |env| [200, {}, nil] }
+      end
+
+      response = http_client(connection).get('http://httpbin.org/get')
       expect(response.status).to eq 200
     end
 
     it 'should execute put' do
-      response = @http_client.put('http://httpbin.org/put', data: { name: 'Alfred' })
+      connection = faraday_connection do |stubs|
+        # Note: request body is serialized as url-encoded so the stub body must be in the same format to match
+        stubs.put('http://httpbin.org/put', 'name=Alfred') { |env| [200, {}, nil] }
+      end
+
+      response = http_client(connection).put('http://httpbin.org/put', data: { name: 'Alfred' })
       expect(response.status).to eq 200
     end
 
     it 'should execute post' do
-      response = @http_client.post('http://httpbin.org/post', data: { name: 'Alfred' })
+      connection = faraday_connection do |stubs|
+        # Note: request body is serialized as url-encoded so the stub body must be in the same format to match
+        stubs.post('http://httpbin.org/post', 'name=Alfred') { |env| [200, {}, %{"name": "Alfred"}] }
+      end
+
+      response = http_client(connection).post('http://httpbin.org/post', data: { name: 'Alfred' })
+
       expect(response.body).to include "name\": \"Alfred"
       expect(response.status).to eq 200
     end
 
     it 'should execute delete' do
-      response = @http_client.delete('http://httpbin.org/delete')
+      connection = faraday_connection do |stubs|
+        stubs.delete('http://httpbin.org/delete') { |env| [200, {}, nil] }
+      end
+
+      response = http_client(connection).delete('http://httpbin.org/delete')
+
       expect(response.status).to eq 200
     end
 
     it 'put should raise error 422' do
-      expect { @http_client.put('http://httpbin.org/status/422', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::UnprocessableEntity)
+      connection = faraday_connection do |stubs|
+        stubs.put('http://httpbin.org/status/422') { |env| [422, {}, nil] }
+      end
+
+      expect { http_client(connection).put('http://httpbin.org/status/422') }.to raise_error(RestfulResource::HttpClient::UnprocessableEntity)
     end
 
     it 'post should raise error 422' do
-      expect { @http_client.post('http://httpbin.org/status/422', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::UnprocessableEntity)
+      connection = faraday_connection do |stubs|
+        stubs.post('http://httpbin.org/status/422') { |env| [422, {}, nil] }
+      end
+
+      expect { http_client(connection).post('http://httpbin.org/status/422') }.to raise_error(RestfulResource::HttpClient::UnprocessableEntity)
     end
 
     it 'put should raise error 503' do
-      expect { @http_client.put('http://httpbin.org/status/503', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::ServiceUnavailable)
+      connection = faraday_connection do |stubs|
+        stubs.put('http://httpbin.org/status/503') { |env| [503, {}, nil] }
+      end
+
+      expect { http_client(connection).put('http://httpbin.org/status/503') }.to raise_error(RestfulResource::HttpClient::ServiceUnavailable)
     end
 
     it 'post should raise error 503' do
-      expect { @http_client.post('http://httpbin.org/status/503', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::ServiceUnavailable)
+      connection = faraday_connection do |stubs|
+        stubs.post('http://httpbin.org/status/503') { |env| [503, {}, nil] }
+      end
+
+      expect { http_client(connection).post('http://httpbin.org/status/503') }.to raise_error(RestfulResource::HttpClient::ServiceUnavailable)
     end
 
     it 'should raise error on 404' do
-      expect { @http_client.get('http://httpbin.org/status/404') }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
-      expect { @http_client.delete('http://httpbin.org/status/404') }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
-      expect { @http_client.put('http://httpbin.org/status/404', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
-      expect { @http_client.post('http://httpbin.org/status/404', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
+      connection = faraday_connection do |stubs|
+        stubs.get('http://httpbin.org/status/404') { |env| [404, {}, nil] }
+        stubs.post('http://httpbin.org/status/404') { |env| [404, {}, nil] }
+        stubs.put('http://httpbin.org/status/404') { |env| [404, {}, nil] }
+        stubs.delete('http://httpbin.org/status/404') { |env| [404, {}, nil] }
+      end
+
+      expect { http_client(connection).get('http://httpbin.org/status/404') }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
+      expect { http_client(connection).delete('http://httpbin.org/status/404') }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
+      expect { http_client(connection).put('http://httpbin.org/status/404', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
+      expect { http_client(connection).post('http://httpbin.org/status/404', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
     end
 
-    it 'should raise normal exception' do
-      expect { @http_client.get('https://localhost:3005') }.to raise_error(Faraday::ConnectionFailed)
+    it 'should raise Faraday::ConnectionFailed errors' do
+      connection = faraday_connection do |stubs|
+        stubs.get('https://localhost:3005') {|env| raise Faraday::ConnectionFailed.new(nil) }
+      end
+
+      expect { http_client(connection).get('https://localhost:3005') }.to raise_error(Faraday::ConnectionFailed)
+    end
+
+    it 'raises ClientError when a client errors with no response' do
+      connection = faraday_connection do |stubs|
+        stubs.get('https://localhost:3005') {|env| raise Faraday::ClientError.new(nil) }
+      end
+
+      expect { http_client(connection).get('https://localhost:3005') }.to raise_error(RestfulResource::HttpClient::ClientError)
+    end
+
+    it 'raises OtherHttpError for other status response codes' do
+      connection = faraday_connection do |stubs|
+        stubs.get('http://httpbin.org/status/418') { |env| [418, {}, nil] }
+      end
+
+      expect { http_client(connection).get('http://httpbin.org/status/418') }.to raise_error(RestfulResource::HttpClient::OtherHttpError)
     end
   end
 
   describe 'Authentication' do
-    before :each do
-      @http_client = RestfulResource::HttpClient.new(username: 'user', password: 'passwd')
+    def http_client(connection)
+      described_class.new(connection: connection, username: 'user', password: 'passwd')
     end
 
     it 'should execute authenticated get' do
-      response = @http_client.get('http://httpbin.org/basic-auth/user/passwd')
+      connection = faraday_connection do |stubs|
+        stubs.get('http://httpbin.org/basic-auth/user/passwd', { "Authorization"=>"Basic dXNlcjpwYXNzd2Q=" }) { |env| [200, {}, nil] }
+      end
+
+      response = http_client(connection).get('http://httpbin.org/basic-auth/user/passwd')
+
       expect(response.status).to eq 200
     end
   end


### PR DESCRIPTION
Fixes a type error in ClientError class that prevented it being initialised correctly. (typo s/initalize/initialize)

Replace making actual http calls to httpbin.org service in tests with mocks using Faraday test adapter. This makes the tests much faster and solves the situation where httpbin.org goes down and causes all our tests to fail :(

Also added tests to check Faraday configuration and other Error classes