### PR TITLE
Get validations

### DIFF
--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -31,9 +31,9 @@ module RestfulResource
       self.paginate_response(response)
     end
 
-    def self.get(params={})
+    def self.get(params = {})
       response = http.get(collection_url(params))
-      RestfulResource::OpenObject.new(parse_json(response.body))
+      self.new(parse_json(response.body))
     end
 
     def self.delete(id, **params)

--- a/lib/restful_resource/rails_validations.rb
+++ b/lib/restful_resource/rails_validations.rb
@@ -31,6 +31,21 @@ module RestfulResource
           self.new(result)
         end
       end
+
+      def get(params = {})
+        begin
+          super(params)
+        rescue HttpClient::UnprocessableEntity => e
+          errors = parse_json(e.response.body)
+          result = nil
+          if errors.is_a?(Hash) && errors.has_key?('errors')
+            result = {}.merge(errors)
+          else
+            result = {}.merge(errors: errors)
+          end
+          self.new(result)
+        end
+      end
     end
 
     def self.included(base)

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -123,13 +123,12 @@ describe RestfulResource::Base do
 
   describe "#get" do
     it "should return an open_object" do
-      expected_response = RestfulResource::Response.new(body: {average_score: 4.3}.to_json)
+      expected_response = RestfulResource::Response.new(body: {average_score: 4.3}.to_json, status: 200)
       expect_get('http://api.carwow.co.uk/makes/average_score?make_slug%5B%5D=Volkswagen&make_slug%5B%5D=Audi', expected_response)
 
       object = Make.action(:average_score).get(make_slug: ['Volkswagen', 'Audi'])
 
       expect(object.average_score).to eq 4.3
-      expect(object.class).to eq RestfulResource::OpenObject
     end
   end
 

--- a/spec/restful_resource/rails_validations_spec.rb
+++ b/spec/restful_resource/rails_validations_spec.rb
@@ -126,4 +126,52 @@ describe RestfulResource::RailsValidations do
       expect(@object.errors).to eq @error
     end
   end
+
+  context "#get without errors" do
+    before :each do
+      expected_response = RestfulResource::Response.new(body: {name: 'Barak'}.to_json)
+      expect_get("http://api.carwow.co.uk/dealers", expected_response)
+
+      @object = Dealer.get
+    end
+
+    it 'should return object' do
+      expect(@object.name).to eq 'Barak'
+    end
+
+    it 'should return valid object' do
+      expect(@object.valid?).to be_truthy
+    end
+  end
+
+  context "#get with errors" do
+    before :each do
+      @error = 'Missing parameter'
+      expected_response = RestfulResource::Response.new(body: {errors: [@error]}.to_json)
+      expect_get_with_unprocessable_entity("http://api.carwow.co.uk/dealers", expected_response)
+
+      @object = Dealer.get
+    end
+
+    it "should have an error" do
+      expect(@object.errors.count).to eq 1
+    end
+
+    it 'should have correct error' do
+      expect(@object.errors.first).to eq @error
+    end
+
+    it 'should return not valid object' do
+      expect(@object.valid?).to be_falsey
+    end
+
+    it 'should handle errors returned as root object' do
+      expected_response = RestfulResource::Response.new(body: @error.to_json)
+      expect_get_with_unprocessable_entity("http://api.carwow.co.uk/dealers", expected_response)
+
+      @object = Dealer.get
+      expect(@object.valid?).to be_falsey
+      expect(@object.errors).to eq @error
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,13 @@ def expect_post(url, response, data: {})
   expect(@mock_http).to receive(:post).with(url, data: data).and_return(response)
 end
 
+def expect_get_with_unprocessable_entity(url, response)
+  request = RestfulResource::Request.new(:get, url)
+  rest_client_response = OpenStruct.new({body: response.body, headers: response.headers, code: response.status})
+  exception = RestfulResource::HttpClient::UnprocessableEntity.new(request, rest_client_response)
+  expect(@mock_http).to receive(:get).with(url).and_raise(exception)
+end
+
 def expect_put_with_unprocessable_entity(url, response, data: {})
   request = RestfulResource::Request.new(:put, url, body: data)
   rest_client_response = OpenStruct.new({body: response.body, headers: response.headers, code: response.status})


### PR DESCRIPTION
# Minor Release: #get validations

* Added validations to #get requests, this should not be breaking old code
* Possibly breaking: Unified Base#get to other methods, now returns self.new instead of OpenObject.new