### PR TITLE
Handle Timeout errors

### DIFF
--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -24,19 +24,25 @@ module RestfulResource
 
     class ResourceNotFound < HttpError
       def message
-        "404 Resource Not Found"
+        "HTTP 404: Resource Not Found"
       end
     end
 
     class OtherHttpError < HttpError
       def message
-        "Http Error - Status code: #{response.status}"
+        "HTTP Error - Status code: #{response.status}"
       end
     end
 
     class ServiceUnavailable < HttpError
       def message
         "HTTP 503: Service unavailable"
+      end
+    end
+
+    class Timeout < HttpError
+      def message
+        "Timeout: Service not responding"
       end
     end
 
@@ -108,6 +114,8 @@ module RestfulResource
       Response.new(body: response.body, headers: response.headers, status: response.status)
     rescue Faraday::ConnectionFailed
       raise
+    rescue Faraday::TimeoutError
+      raise HttpClient::Timeout.new(request)
     rescue Faraday::ClientError => e
       response = e.response
       raise ClientError.new(request) unless response

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -111,6 +111,14 @@ describe RestfulResource::HttpClient do
       expect { http_client(connection).get('https://localhost:3005') }.to raise_error(Faraday::ConnectionFailed)
     end
 
+    it 'should raise Timeout error' do
+      connection = faraday_connection do |stubs|
+        stubs.get('https://localhost:3005') {|env| raise Faraday::TimeoutError.new(nil) }
+      end
+
+      expect { http_client(connection).get('https://localhost:3005') }.to raise_error(RestfulResource::HttpClient::Timeout)
+    end
+
     it 'raises ClientError when a client errors with no response' do
       connection = faraday_connection do |stubs|
         stubs.get('https://localhost:3005') {|env| raise Faraday::ClientError.new(nil) }


### PR DESCRIPTION
By Handle I mean report outside of RestfulResource so that we can handle them in our apps via retry etc...