### PR TITLE
Add BadGateway as RetryableError

### DIFF
--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -36,6 +36,12 @@ module RestfulResource
       end
     end
 
+    class BadGateway < RetryableError
+      def message
+        "HTTP 502: Bad gateway"
+      end
+    end
+
     class ServiceUnavailable < RetryableError
       def message
         "HTTP 503: Service unavailable"
@@ -156,6 +162,7 @@ module RestfulResource
       case response[:status]
       when 404 then raise HttpClient::ResourceNotFound.new(request, response)
       when 422 then raise HttpClient::UnprocessableEntity.new(request, response)
+      when 502 then raise HttpClient::BadGateway.new(request, response)
       when 503 then raise HttpClient::ServiceUnavailable.new(request, response)
       else raise HttpClient::OtherHttpError.new(request, response)
       end

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -73,6 +73,22 @@ describe RestfulResource::HttpClient do
       expect { http_client(connection).post('http://httpbin.org/status/422') }.to raise_error(RestfulResource::HttpClient::UnprocessableEntity)
     end
 
+    it 'put should raise error 502' do
+      connection = faraday_connection do |stubs|
+        stubs.put('http://httpbin.org/status/502') { |env| [502, {}, nil] }
+      end
+
+      expect { http_client(connection).put('http://httpbin.org/status/502') }.to raise_error(RestfulResource::HttpClient::BadGateway)
+    end
+
+    it 'post should raise error 502' do
+      connection = faraday_connection do |stubs|
+        stubs.post('http://httpbin.org/status/502') { |env| [502, {}, nil] }
+      end
+
+      expect { http_client(connection).post('http://httpbin.org/status/502') }.to raise_error(RestfulResource::HttpClient::BadGateway)
+    end
+
     it 'put should raise error 503' do
       connection = faraday_connection do |stubs|
         stubs.put('http://httpbin.org/status/503') { |env| [503, {}, nil] }


### PR DESCRIPTION
I created this PR as an alternate solution at the library level for https://github.com/carwow/quotes_site/pull/2171.

We now have a few more errors coming from another job that uses the Iterable API:
https://app.bugsnag.com/carwow/quotes-site/errors/59de6163d7166600187fbdcb?filters%5Bevent.since%5D%5B%5D=30d&filters%5Berror.status%5D%5B%5D=snoozed

Instead of applying the same app level fix there, we could map 502 to `RetryableError`. WDYT?