### PR TITLE
Allow custom headers to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 Provides an ActiveResource like interface to JSON API's
 
+## Caching
+
+Caching using [faraday-http-cache](https://github.com/plataformatec/faraday-http-cache)
+
+Enabled by passing an initialsed cache object (eg Rails.cache)
+
+```
+RestfulResource::Base.configure(
+  base_url: "http://my.api.com/",
+  cache_store: Rails.cache
+)
+```
+
+### Bypassing the cache
+
+To make requests that bypass the local HTTP cache use the `no_cache: true` option eg:
+
+```
+Object.find(1, no_cache: true)
+```
+
+
 ## Metrics
 
 ### HTTP Metrics

--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -23,42 +23,50 @@ module RestfulResource
     end
 
     def self.find(id, params={})
-      response = http.get(member_url(id, params))
+      headers = params.delete(:headers) || {}
+
+      response = http.get(member_url(id, params), headers: headers)
       self.new(parse_json(response.body))
     end
 
     def self.where(params={})
+      headers = params.delete(:headers) || {}
+
       url = collection_url(params)
-      response = http.get(url)
+      response = http.get(url, headers: headers)
       self.paginate_response(response)
     end
 
     def self.get(params = {})
-      response = http.get(collection_url(params))
+      headers = params.delete(:headers) || {}
+
+      response = http.get(collection_url(params), headers: headers)
       self.new(parse_json(response.body))
     end
 
     def self.delete(id, **params)
-      response = http.delete(member_url(id, params))
+      headers = params.delete(:headers) || {}
+
+      response = http.delete(member_url(id, params), headers: headers)
       RestfulResource::OpenObject.new(parse_json(response.body))
     end
 
-    def self.put(id, data: {}, **params)
+    def self.put(id, data: {}, headers: {}, **params)
       url = member_url(id, params)
-      response = http.put(url, data: data)
+      response = http.put(url, data: data, headers: headers)
       self.new(parse_json(response.body))
     end
 
-    def self.post(data: {}, **params)
+    def self.post(data: {}, headers: {}, **params)
       url = collection_url(params)
 
-      response = http.post(url, data: data)
+      response = http.post(url, data: data, headers: headers)
 
       self.new(parse_json(response.body))
     end
 
-    def self.all
-      self.where
+    def self.all(params = {})
+      self.where(params)
     end
 
     def self.action(action_name)

--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -23,24 +23,24 @@ module RestfulResource
     end
 
     def self.find(id, params={})
-      headers = params.delete(:headers) || {}
+      params_without_headers, headers = extract_headers!(params)
 
-      response = http.get(member_url(id, params), headers: headers)
+      response = http.get(member_url(id, params_without_headers), headers: headers)
       self.new(parse_json(response.body))
     end
 
     def self.where(params={})
-      headers = params.delete(:headers) || {}
+      params_without_headers, headers = extract_headers!(params)
 
-      url = collection_url(params)
+      url = collection_url(params_without_headers)
       response = http.get(url, headers: headers)
       self.paginate_response(response)
     end
 
     def self.get(params = {})
-      headers = params.delete(:headers) || {}
+      params_without_headers, headers = extract_headers!(params)
 
-      response = http.get(collection_url(params), headers: headers)
+      response = http.get(collection_url(params_without_headers), headers: headers)
       self.new(parse_json(response.body))
     end
 
@@ -112,6 +112,15 @@ module RestfulResource
     end
 
     private
+
+    def self.extract_headers!(params = {})
+      headers = params.delete(:headers) || {}
+
+      headers.merge!(cache_control: 'no-cache') if params.delete(:no_cache)
+
+      [params, headers]
+    end
+
     def self.merge_url_paths(uri, *paths)
       uri.merge(paths.compact.join('/')).to_s
     end

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -83,20 +83,20 @@ module RestfulResource
       end
     end
 
-    def get(url, accept: 'application/json')
-      http_request(Request.new(:get, url, accept: accept))
+    def get(url, headers: {})
+      http_request(Request.new(:get, url, headers: headers))
     end
 
-    def delete(url, accept: 'application/json')
-      http_request(Request.new(:delete, url, accept: accept))
+    def delete(url, headers: {})
+      http_request(Request.new(:delete, url, headers: headers))
     end
 
-    def put(url, data: {}, accept: 'application/json')
-      http_request(Request.new(:put, url, body: data, accept: accept))
+    def put(url, data: {}, headers: {})
+      http_request(Request.new(:put, url, body: data, headers: headers))
     end
 
-    def post(url, data: {}, accept: 'application/json')
-      http_request(Request.new(:post, url, body: data, accept: accept))
+    def post(url, data: {}, headers: {})
+      http_request(Request.new(:post, url, body: data, headers: headers))
     end
 
     private
@@ -141,9 +141,7 @@ module RestfulResource
         req.body = request.body unless request.body.nil?
         req.url request.url
 
-        if request.accept
-          req.headers['Accept'] = request.accept
-        end
+        req.headers = req.headers.merge(request.headers)
       end
       Response.new(body: response.body, headers: response.headers, status: response.status)
     rescue Faraday::ConnectionFailed

--- a/lib/restful_resource/rails_validations.rb
+++ b/lib/restful_resource/rails_validations.rb
@@ -1,9 +1,9 @@
 module RestfulResource
   module RailsValidations
     module ClassMethods
-      def put(id, data: {}, **params)
+      def put(id, data: {}, headers: {}, **params)
         begin
-          super(id, data: data, **params)
+          super(id, data: data, headers: {}, **params)
         rescue HttpClient::UnprocessableEntity => e
           errors = parse_json(e.response.body)
           result = nil
@@ -17,9 +17,9 @@ module RestfulResource
         end
       end
 
-      def post(data: {}, **params)
+      def post(data: {}, headers: {}, **params)
         with_validations(data: data) do
-          super(data: data, **params)
+          super(data: data, headers: {}, **params)
         end
       end
 

--- a/lib/restful_resource/redirections.rb
+++ b/lib/restful_resource/redirections.rb
@@ -8,10 +8,10 @@ module RestfulResource
   module Redirections
     def self.included(base)
       base.instance_eval do
-        def post(data: {}, delay: 1.0, max_attempts: 10, **params)
+        def post(data: {}, delay: 1.0, max_attempts: 10, headers: {}, **params)
           url = collection_url(params)
 
-          response = self.accept_redirected_result(response: http.post(url, data: data), delay: delay, max_attempts: max_attempts)
+          response = self.accept_redirected_result(response: http.post(url, data: data, headers: headers), delay: delay, max_attempts: max_attempts)
 
           self.new(parse_json(response.body))
         end
@@ -24,12 +24,12 @@ module RestfulResource
             resource_location = response.headers[:location]
 
             RestfulResource::Redirections.wait(delay)
-            new_response = http.get(resource_location)
+            new_response = http.get(resource_location, headers: {})
 
             while (new_response.status == 202) && (attempts < max_attempts)
               attempts += 1
               RestfulResource::Redirections.wait(delay)
-              new_response = http.get(resource_location)
+              new_response = http.get(resource_location, headers: {})
             end
 
             if attempts == max_attempts

--- a/lib/restful_resource/request.rb
+++ b/lib/restful_resource/request.rb
@@ -1,9 +1,31 @@
 module RestfulResource
   class Request
-    attr_reader :body, :method, :url, :accept
+    attr_reader :body, :method, :url
 
-    def initialize(method, url, accept: 'application/json', body: nil)
-      @method, @url, @accept, @body = method, url, accept, body
+    def initialize(method, url, headers: {}, body: nil)
+      @method, @url, @headers, @body = method, url, headers, body
+    end
+
+    def headers
+      default_headers.merge(format_headers)
+    end
+
+    private
+
+    # Formats all keys in Word-Word format
+    def format_headers
+      @headers.stringify_keys.inject({}) do |h, key_with_value|
+        h[format_key key_with_value.first] = key_with_value.last
+        h
+      end
+    end
+
+    def format_key(key)
+      key.humanize.split(' ').map(&:humanize).join('-')
+    end
+
+    def default_headers
+      { 'Accept' => 'application/json' }
     end
   end
 end

--- a/restful_resource.gemspec
+++ b/restful_resource.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.1"
+  spec.add_development_dependency "rspec-its"
 
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../spec_helper'
 
-describe RestfulResource::Base do
-  before :each do
+RSpec.describe RestfulResource::Base do
+  before do
     @mock_http = double("mock_http")
     allow(RestfulResource::Base).to receive(:http).and_return(@mock_http)
     RestfulResource::Base.configure(base_url: 'http://api.carwow.co.uk/')
@@ -49,6 +49,14 @@ describe RestfulResource::Base do
 
       object = Model.find('Golf Cabriolet?test', make_slug: 'Land Rover?x=0.123', group_id: 'xxx yyy?l=7')
     end
+
+    it 'accepts custom headers' do
+      expect_get("http://api.carwow.co.uk/makes/12",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Make.find(12, headers: { cache_control: 'no-cache' })
+    end
   end
 
   describe "#where" do
@@ -74,6 +82,14 @@ describe RestfulResource::Base do
       expect(models.previous_page).to be_nil
       expect(models.next_page).to eq 2
     end
+
+    it 'accepts custom headers' do
+      expect_get("http://api.carwow.co.uk/groups/15/makes/Volkswagen/models?on_sale=true",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Model.where(make_slug: 'Volkswagen', on_sale: true, group_id: 15, headers: { cache_control: 'no-cache' })
+    end
   end
 
   describe "#all" do
@@ -85,6 +101,14 @@ describe RestfulResource::Base do
       expect(makes).not_to be_nil
       expect(makes.length).to eq 2
       expect(makes.first.name).to eq 'Volkswagen'
+    end
+
+    it 'accepts custom headers' do
+      expect_get("http://api.carwow.co.uk/makes",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Make.all(headers: { cache_control: 'no-cache' })
     end
   end
 
@@ -130,6 +154,14 @@ describe RestfulResource::Base do
 
       expect(object.average_score).to eq 4.3
     end
+
+    it 'accepts custom headers' do
+      expect_get("http://api.carwow.co.uk/makes/average_score",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Make.action(:average_score).get(headers: { cache_control: 'no-cache' })
+    end
   end
 
   describe "#put" do
@@ -172,6 +204,14 @@ describe RestfulResource::Base do
 
       expect(object.name).to eq 'Audi'
     end
+
+    it 'accepts custom headers' do
+      expect_put("http://api.carwow.co.uk/makes/1",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Make.put(1, data: {}, headers: { cache_control: 'no-cache' })
+    end
   end
 
   describe "#post" do
@@ -186,6 +226,14 @@ describe RestfulResource::Base do
       expect(object.name).to eq 'Audi'
       expect(object.num_of_cars).to eq 3
     end
+
+    it 'accepts custom headers' do
+      expect_post("http://api.carwow.co.uk/makes",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Make.post(data: {}, headers: { cache_control: 'no-cache' })
+    end
   end
 
   describe "#delete" do
@@ -196,6 +244,14 @@ describe RestfulResource::Base do
       object = Make.delete(1)
 
       expect(object.deleted).to be_truthy
+    end
+
+    it 'accepts custom headers' do
+      expect_delete("http://api.carwow.co.uk/makes/1",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Make.delete(1, headers: { cache_control: 'no-cache' })
     end
   end
 

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe RestfulResource::Base do
 
       Make.find(12, headers: { cache_control: 'no-cache' })
     end
+
+    it 'accepts no_cache option' do
+      expect_get("http://api.carwow.co.uk/makes/12",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Make.find(12, no_cache: true)
+    end
   end
 
   describe "#where" do
@@ -90,6 +98,14 @@ RSpec.describe RestfulResource::Base do
 
       Model.where(make_slug: 'Volkswagen', on_sale: true, group_id: 15, headers: { cache_control: 'no-cache' })
     end
+
+    it 'accepts no_cache option' do
+      expect_get("http://api.carwow.co.uk/groups/15/makes/Volkswagen/models?on_sale=true",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Model.where(make_slug: 'Volkswagen', on_sale: true, group_id: 15, no_cache: true)
+    end
   end
 
   describe "#all" do
@@ -109,6 +125,14 @@ RSpec.describe RestfulResource::Base do
         headers: { cache_control: 'no-cache' })
 
       Make.all(headers: { cache_control: 'no-cache' })
+    end
+
+    it 'accepts no_cache option' do
+      expect_get("http://api.carwow.co.uk/makes",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Make.all(no_cache: true)
     end
   end
 
@@ -162,6 +186,14 @@ RSpec.describe RestfulResource::Base do
 
       Make.action(:average_score).get(headers: { cache_control: 'no-cache' })
     end
+
+    it 'accepts no_cache option' do
+      expect_get("http://api.carwow.co.uk/makes/average_score",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      Make.action(:average_score).get(no_cache: true)
+    end
   end
 
   describe "#put" do
@@ -208,9 +240,9 @@ RSpec.describe RestfulResource::Base do
     it 'accepts custom headers' do
       expect_put("http://api.carwow.co.uk/makes/1",
         RestfulResource::Response.new,
-        headers: { cache_control: 'no-cache' })
+        headers: { accept: 'application/json' })
 
-      Make.put(1, data: {}, headers: { cache_control: 'no-cache' })
+      Make.put(1, data: {}, headers: { accept: 'application/json' })
     end
   end
 
@@ -230,9 +262,9 @@ RSpec.describe RestfulResource::Base do
     it 'accepts custom headers' do
       expect_post("http://api.carwow.co.uk/makes",
         RestfulResource::Response.new,
-        headers: { cache_control: 'no-cache' })
+        headers: { accept: 'application/json' })
 
-      Make.post(data: {}, headers: { cache_control: 'no-cache' })
+      Make.post(data: {}, headers: { accept: 'application/json' })
     end
   end
 
@@ -249,9 +281,9 @@ RSpec.describe RestfulResource::Base do
     it 'accepts custom headers' do
       expect_delete("http://api.carwow.co.uk/makes/1",
         RestfulResource::Response.new,
-        headers: { cache_control: 'no-cache' })
+        headers: { accept: 'application/json' })
 
-      Make.delete(1, headers: { cache_control: 'no-cache' })
+      Make.delete(1, headers: { accept: 'application/json' })
     end
   end
 

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../spec_helper'
 
-describe RestfulResource::HttpClient do
+RSpec.describe RestfulResource::HttpClient do
   def faraday_connection
     Faraday.new do |builder|
       builder.request :url_encoded
@@ -143,11 +143,22 @@ describe RestfulResource::HttpClient do
 
     it 'should execute authenticated get' do
       connection = faraday_connection do |stubs|
-        stubs.get('http://httpbin.org/basic-auth/user/passwd', { "Authorization"=>"Basic dXNlcjpwYXNzd2Q=" }) { |env| [200, {}, nil] }
+        stubs.get('http://httpbin.org/basic-auth/user/passwd') { |env| [200, {}, nil] }
       end
 
-      response = http_client(connection).get('http://httpbin.org/basic-auth/user/passwd')
+      response = http_client(connection).get('http://httpbin.org/basic-auth/user/passwd', headers: {"Authorization"=>"Basic dXNlcjpwYXNzd2Q="})
 
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe 'Headers' do
+    it 'uses custom headers' do
+      connection = faraday_connection do |stubs|
+        stubs.get('http://httpbin.org/get', { 'Cache-Control' => 'no-cache' }) { |env| [200, {}, nil] }
+      end
+
+      response = http_client(connection).get('http://httpbin.org/get', headers: { cache_control: 'no-cache' })
       expect(response.status).to eq 200
     end
   end

--- a/spec/restful_resource/rails_validations_spec.rb
+++ b/spec/restful_resource/rails_validations_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../spec_helper'
 
-describe RestfulResource::RailsValidations do
+RSpec.describe RestfulResource::RailsValidations do
   before :each do
     @mock_http = double("mock_http")
     RestfulResource::Base.configure(base_url: "http://api.carwow.co.uk/")
@@ -26,7 +26,7 @@ describe RestfulResource::RailsValidations do
   end
 
   context "#put with errors" do
-    before :each do
+    before do
       data = {name: 'Leonardo'}
       @error = 'Cannot use Ninja Turtles names'
       expected_response = RestfulResource::Response.new(body: {errors: [@error]}.to_json)

--- a/spec/restful_resource/redirections_spec.rb
+++ b/spec/restful_resource/redirections_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../spec_helper'
 
-describe RestfulResource::Redirections do
-  before :each do
+RSpec.describe RestfulResource::Redirections do
+  before do
     @mock_http = double("mock_http")
     allow(RestfulResource::Base).to receive(:http).and_return(@mock_http)
     RestfulResource::Base.configure(base_url: 'http://api.carwow.co.uk/')
@@ -24,7 +24,7 @@ describe RestfulResource::Redirections do
     context 'with a redirect to resource location' do
       let(:redirect_target) { 'http://api.carwow.co.uk/model_with_redirections/123' }
 
-      before(:each) do
+      before do
         allow(RestfulResource::Redirections).to receive(:wait)
         expected_redirect_response = RestfulResource::Response.new(body: 'You are being redirected', status: 303, headers: { location: redirect_target})
         expect_post("http://api.carwow.co.uk/model_with_redirections", expected_redirect_response, data: data)

--- a/spec/restful_resource/request_spec.rb
+++ b/spec/restful_resource/request_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe RestfulResource::Request do
+  let(:method) { 'get' }
+  let(:url) { 'https://www.carwow.co.uk/api/v2/models' }
+
+  describe '.headers' do
+    context 'given no headers' do
+      subject { described_class.new(method, url).headers }
+
+      its(['Accept']) { is_expected.to eq 'application/json' }
+    end
+
+    context 'given an explicit accept header' do
+      subject { described_class.new(method, url, headers: { accept: 'application/xml' }).headers }
+
+      its(['Accept']) { is_expected.to eq 'application/xml' }
+    end
+
+    context 'given symbolized header' do
+      subject { described_class.new(method, url, headers: { authorization: 'Bearer: xyz' }).headers }
+
+      its(['Authorization']) { is_expected.to eq 'Bearer: xyz' }
+      its(['Accept']) { is_expected.to eq 'application/json' }
+    end
+
+    context 'given multi word symbolized header' do
+      subject { described_class.new(method, url, headers: { cache_control: 'no-cache' }).headers }
+
+      its(['Cache-Control']) { is_expected.to eq 'no-cache' }
+      its(['Accept']) { is_expected.to eq 'application/json' }
+    end
+
+    context 'given string header' do
+      subject { described_class.new(method, url, headers: { 'authorization' => 'Bearer: xyz' }).headers }
+
+      its(['Authorization']) { is_expected.to eq 'Bearer: xyz' }
+      its(['Accept']) { is_expected.to eq 'application/json' }
+    end
+
+    context 'given multi word string header' do
+      subject { described_class.new(method, url, headers: { 'cache control' => 'no-cache' }).headers }
+
+      its(['Cache-Control']) { is_expected.to eq 'no-cache' }
+      its(['Accept']) { is_expected.to eq 'application/json' }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'rspec'
+require 'rspec/its'
 require_relative '../lib/restful_resource'
 require_relative 'fixtures'
 
@@ -8,39 +9,39 @@ RSpec.configure do |config|
 end
 
 
-def expect_get(url, response)
-  expect(@mock_http).to receive(:get).with(url).and_return(response)
+def expect_get(url, response, headers: {})
+  expect(@mock_http).to receive(:get).with(url, headers: headers).and_return(response)
 end
 
-def expect_delete(url, response)
-  expect(@mock_http).to receive(:delete).with(url).and_return(response)
+def expect_delete(url, response, headers: {})
+  expect(@mock_http).to receive(:delete).with(url, headers: headers).and_return(response)
 end
 
-def expect_put(url, response, data: {})
-  expect(@mock_http).to receive(:put).with(url, data: data).and_return(response)
+def expect_put(url, response, data: {}, headers: {})
+  expect(@mock_http).to receive(:put).with(url, data: data, headers: headers).and_return(response)
 end
 
-def expect_post(url, response, data: {})
-  expect(@mock_http).to receive(:post).with(url, data: data).and_return(response)
+def expect_post(url, response, data: {}, headers: {})
+  expect(@mock_http).to receive(:post).with(url, data: data, headers: headers).and_return(response)
 end
 
 def expect_get_with_unprocessable_entity(url, response)
   request = RestfulResource::Request.new(:get, url)
   rest_client_response = OpenStruct.new({body: response.body, headers: response.headers, code: response.status})
   exception = RestfulResource::HttpClient::UnprocessableEntity.new(request, rest_client_response)
-  expect(@mock_http).to receive(:get).with(url).and_raise(exception)
+  expect(@mock_http).to receive(:get).with(url, headers: {}).and_raise(exception)
 end
 
 def expect_put_with_unprocessable_entity(url, response, data: {})
   request = RestfulResource::Request.new(:put, url, body: data)
   rest_client_response = OpenStruct.new({body: response.body, headers: response.headers, code: response.status})
   exception = RestfulResource::HttpClient::UnprocessableEntity.new(request, rest_client_response)
-  expect(@mock_http).to receive(:put).with(url, data: data).and_raise(exception)
+  expect(@mock_http).to receive(:put).with(url, data: data, headers: {}).and_raise(exception)
 end
 
 def expect_post_with_unprocessable_entity(url, response, data: {})
   request = RestfulResource::Request.new(:put, url, body: data)
   rest_client_response = OpenStruct.new({body: response.body, headers: response.headers, code: response.status})
   exception = RestfulResource::HttpClient::UnprocessableEntity.new(request, rest_client_response)
-  expect(@mock_http).to receive(:post).with(url, data: data).and_raise(exception)
+  expect(@mock_http).to receive(:post).with(url, data: data, headers: {}).and_raise(exception)
 end


### PR DESCRIPTION
Expose an optional headers hash when making API calls. This allows custom headers to be sent
to the origin server. All provided headers are sent to the server.

If the `Accept` header is not supplied then `application/json` is used as a default.

eg

```
Model.find(1, headers: { cache_control: 'no-cache'})
# or
Model.get('path', headers: { cache_control: 'no-cache'})
# or
Model.where(param: 123, headers: { cache_control: 'no-cache'})
# or use the short hand
Model.where(param: 123, no_cache: true)
```

Will make the HTTP request with `Cache-Control: no-cache` header