### PR TITLE
Make (open_)timeout configurable globally and per-request

### DIFF
--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -59,9 +59,9 @@ module RestfulResource
                    logger: nil,
                    cache_store: nil,
                    connection: nil,
-                   instrumentation: {})
-
-
+                   instrumentation: {},
+                   open_timeout: 2,
+                   timeout: 10)
       api_name = instrumentation[:api_name]     ||= 'api'
       instrumentation[:request_instrument_name] ||= "http.#{api_name}"
       instrumentation[:cache_instrument_name]   ||= "http_cache.#{api_name}"
@@ -78,28 +78,64 @@ module RestfulResource
                                                         request_instrument_name: instrumentation.fetch(:request_instrument_name, nil),
                                                         cache_instrument_name: instrumentation.fetch(:cache_instrument_name, nil))
 
-      if username && password
-        @connection.basic_auth username, password
-      end
+      @connection.basic_auth(username, password) if username && password
+      @default_open_timeout = open_timeout
+      @default_timeout = timeout
     end
 
-    def get(url, headers: {})
-      http_request(Request.new(:get, url, headers: headers))
+    def get(url, headers: {}, open_timeout: nil, timeout: nil)
+      http_request(
+        Request.new(
+          :get,
+          url,
+          headers: headers,
+          open_timeout: open_timeout,
+          timeout: timeout
+        )
+      )
     end
 
-    def delete(url, headers: {})
-      http_request(Request.new(:delete, url, headers: headers))
+    def delete(url, headers: {}, open_timeout: nil, timeout: nil)
+      http_request(
+        Request.new(
+          :delete,
+          url,
+          headers: headers,
+          open_timeout: open_timeout,
+          timeout: timeout
+        )
+      )
     end
 
-    def put(url, data: {}, headers: {})
-      http_request(Request.new(:put, url, body: data, headers: headers))
+    def put(url, data: {}, headers: {}, open_timeout: nil, timeout: nil)
+      http_request(
+        Request.new(
+          :put,
+          url,
+          body: data,
+          headers: headers,
+          open_timeout: open_timeout,
+          timeout: timeout
+        )
+      )
     end
 
-    def post(url, data: {}, headers: {})
-      http_request(Request.new(:post, url, body: data, headers: headers))
+    def post(url, data: {}, headers: {}, open_timeout: nil, timeout: nil)
+      http_request(
+        Request.new(
+          :post,
+          url,
+          body: data,
+          headers: headers,
+          open_timeout: open_timeout,
+          timeout: timeout
+        )
+      )
     end
 
     private
+
+    attr_reader :default_open_timeout, :default_timeout
 
     def initialize_connection(logger: nil,
                               cache_store: nil,
@@ -135,8 +171,8 @@ module RestfulResource
 
     def http_request(request)
       response = @connection.send(request.method) do |req|
-        req.options.open_timeout = 2 # seconds
-        req.options.timeout = 10 # seconds
+        req.options.open_timeout = request.open_timeout || default_open_timeout # seconds
+        req.options.timeout = request.timeout || default_timeout # seconds
 
         req.body = request.body unless request.body.nil?
         req.url request.url

--- a/lib/restful_resource/redirections.rb
+++ b/lib/restful_resource/redirections.rb
@@ -8,10 +8,10 @@ module RestfulResource
   module Redirections
     def self.included(base)
       base.instance_eval do
-        def post(data: {}, delay: 1.0, max_attempts: 10, headers: {}, **params)
+        def post(data: {}, delay: 1.0, max_attempts: 10, headers: {}, open_timeout: nil, timeout: nil, **params)
           url = collection_url(params)
 
-          response = self.accept_redirected_result(response: http.post(url, data: data, headers: headers), delay: delay, max_attempts: max_attempts)
+          response = self.accept_redirected_result(response: http.post(url, data: data, headers: headers, open_timeout: nil, timeout: nil), delay: delay, max_attempts: max_attempts)
 
           self.new(parse_json(response.body))
         end
@@ -24,12 +24,12 @@ module RestfulResource
             resource_location = response.headers[:location]
 
             RestfulResource::Redirections.wait(delay)
-            new_response = http.get(resource_location, headers: {})
+            new_response = http.get(resource_location, headers: {}, open_timeout: nil, timeout: nil)
 
             while (new_response.status == 202) && (attempts < max_attempts)
               attempts += 1
               RestfulResource::Redirections.wait(delay)
-              new_response = http.get(resource_location, headers: {})
+              new_response = http.get(resource_location, headers: {}, open_timeout: nil, timeout: nil)
             end
 
             if attempts == max_attempts

--- a/lib/restful_resource/request.rb
+++ b/lib/restful_resource/request.rb
@@ -1,9 +1,14 @@
 module RestfulResource
   class Request
-    attr_reader :body, :method, :url
+    attr_reader :body, :method, :url, :open_timeout, :timeout
 
-    def initialize(method, url, headers: {}, body: nil)
-      @method, @url, @headers, @body = method, url, headers, body
+    def initialize(method, url, headers: {}, body: nil, open_timeout: nil, timeout: nil)
+      @method = method
+      @url = url
+      @headers = headers
+      @body = body
+      @open_timeout = open_timeout
+      @timeout = timeout
     end
 
     def headers
@@ -14,9 +19,8 @@ module RestfulResource
 
     # Formats all keys in Word-Word format
     def format_headers
-      @headers.stringify_keys.inject({}) do |h, key_with_value|
-        h[format_key key_with_value.first] = key_with_value.last
-        h
+      @headers.stringify_keys.each_with_object({}) do |key_with_value, headers|
+        headers[format_key(key_with_value.first)] = key_with_value.last
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,39 +9,47 @@ RSpec.configure do |config|
 end
 
 
-def expect_get(url, response, headers: {})
-  expect(@mock_http).to receive(:get).with(url, headers: headers).and_return(response)
+def expect_get(url, response, headers: {}, open_timeout: nil, timeout: nil)
+  expect(@mock_http).to receive(:get)
+    .with(url, headers: headers, open_timeout: open_timeout, timeout: timeout)
+    .and_return(response)
 end
 
-def expect_delete(url, response, headers: {})
-  expect(@mock_http).to receive(:delete).with(url, headers: headers).and_return(response)
+def expect_delete(url, response, headers: {}, open_timeout: nil, timeout: nil)
+  expect(@mock_http).to receive(:delete)
+    .with(url, headers: headers, open_timeout: open_timeout, timeout: timeout)
+    .and_return(response)
 end
 
-def expect_put(url, response, data: {}, headers: {})
-  expect(@mock_http).to receive(:put).with(url, data: data, headers: headers).and_return(response)
+def expect_put(url, response, data: {}, headers: {}, open_timeout: nil, timeout: nil)
+  expect(@mock_http).to receive(:put)
+    .with(url, data: data, headers: headers, open_timeout: open_timeout, timeout: timeout)
+    .and_return(response)
 end
 
-def expect_post(url, response, data: {}, headers: {})
-  expect(@mock_http).to receive(:post).with(url, data: data, headers: headers).and_return(response)
+def expect_post(url, response, data: {}, headers: {}, open_timeout: nil, timeout: nil)
+  expect(@mock_http).to receive(:post)
+    .with(url, data: data, headers: headers, open_timeout: open_timeout, timeout: timeout)
+    .and_return(response)
 end
 
 def expect_get_with_unprocessable_entity(url, response)
   request = RestfulResource::Request.new(:get, url)
   rest_client_response = OpenStruct.new({body: response.body, headers: response.headers, code: response.status})
   exception = RestfulResource::HttpClient::UnprocessableEntity.new(request, rest_client_response)
-  expect(@mock_http).to receive(:get).with(url, headers: {}).and_raise(exception)
+  expect(@mock_http).to receive(:get).with(url, headers: {}, open_timeout: nil, timeout: nil).and_raise(exception)
 end
 
 def expect_put_with_unprocessable_entity(url, response, data: {})
   request = RestfulResource::Request.new(:put, url, body: data)
   rest_client_response = OpenStruct.new({body: response.body, headers: response.headers, code: response.status})
   exception = RestfulResource::HttpClient::UnprocessableEntity.new(request, rest_client_response)
-  expect(@mock_http).to receive(:put).with(url, data: data, headers: {}).and_raise(exception)
+  expect(@mock_http).to receive(:put).with(url, data: data, headers: {}, open_timeout: nil, timeout: nil).and_raise(exception)
 end
 
 def expect_post_with_unprocessable_entity(url, response, data: {})
   request = RestfulResource::Request.new(:put, url, body: data)
   rest_client_response = OpenStruct.new({body: response.body, headers: response.headers, code: response.status})
   exception = RestfulResource::HttpClient::UnprocessableEntity.new(request, rest_client_response)
-  expect(@mock_http).to receive(:post).with(url, data: data, headers: {}).and_raise(exception)
+  expect(@mock_http).to receive(:post).with(url, data: data, headers: {}, open_timeout: nil, timeout: nil).and_raise(exception)
 end


### PR DESCRIPTION
Still default to 2s on open, 10s on request.