### PR TITLE
Add no_count option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ To make requests that bypass the local HTTP cache use the `no_cache: true` optio
 Object.find(1, no_cache: true)
 ```
 
+### Skipping total count calculation
+
+Paginated APIs are expected to return the total number of results in the `X-Total-Count` header
+(which is used to set up the `total_count` attribute of the `PaginatedArray` returned from listing
+methods). However, this can cause a performance hit for listings which return a lot of results.
+Specifying `no_count: true` instructs the server to not populate that header, meaning that the
+result will not have a `total_count` attribute.
+
+```
+results = Object.where(attr1: 'thing', no_count: true)
+results.total_count # => nil
+results.count # => the page size, e.g. 50
+```
+
 
 ## Metrics
 

--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -123,6 +123,7 @@ module RestfulResource
       headers = params.delete(:headers) || {}
 
       headers.merge!(cache_control: 'no-cache') if params.delete(:no_cache)
+      headers.merge!(x_total_count: 'skip') if params.delete(:no_count)
       open_timeout = params.delete(:open_timeout)
       timeout = params.delete(:timeout)
 

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -106,6 +106,14 @@ RSpec.describe RestfulResource::Base do
 
       Model.where(make_slug: 'Volkswagen', on_sale: true, group_id: 15, no_cache: true)
     end
+
+    it 'accepts no_count option' do
+      expect_get("http://api.carwow.co.uk/groups/15/makes/Volkswagen/models?on_sale=true",
+        RestfulResource::Response.new,
+        headers: { x_total_count: 'skip' })
+
+      Model.where(make_slug: 'Volkswagen', on_sale: true, group_id: 15, no_count: true)
+    end
   end
 
   describe "#all" do
@@ -133,6 +141,14 @@ RSpec.describe RestfulResource::Base do
         headers: { cache_control: 'no-cache' })
 
       Make.all(no_cache: true)
+    end
+
+    it 'accepts no_count option' do
+      expect_get("http://api.carwow.co.uk/makes",
+        RestfulResource::Response.new,
+        headers: { x_total_count: 'skip' })
+
+      Make.all(no_count: true)
     end
   end
 


### PR DESCRIPTION
To ask the origin server to not calculate the X-Total-Count response
header (which can be slow!)

Does so by setting `X-Total-Count: skip` in the request.