### PR TITLE
Passing custom config block to faraday

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ test/tmp
 test/version_tmp
 tmp
 .idea
+*.swp
+*.swo

--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -7,7 +7,8 @@ module RestfulResource
                        password: nil,
                        logger: nil,
                        cache_store: nil,
-                       instrumentation: {})
+                       instrumentation: {},
+                       faraday_config: nil)
 
       @base_url = URI.parse(base_url)
 
@@ -15,7 +16,8 @@ module RestfulResource
                                               password: password,
                                               logger: logger,
                                               cache_store: cache_store,
-                                              instrumentation: instrumentation)
+                                              instrumentation: instrumentation,
+                                              faraday_config: faraday_config)
     end
 
     def self.resource_path(url)

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -69,7 +69,8 @@ module RestfulResource
                    connection: nil,
                    instrumentation: {},
                    open_timeout: 2,
-                   timeout: 10)
+                   timeout: 10,
+                   faraday_config: nil)
       api_name = instrumentation[:api_name]            ||= 'api'
       instrumentation[:request_instrument_name]        ||= "http.#{api_name}"
       instrumentation[:cache_instrument_name]          ||= "http_cache.#{api_name}"
@@ -91,7 +92,8 @@ module RestfulResource
                                                         instrumenter: ActiveSupport::Notifications,
                                                         request_instrument_name: instrumentation.fetch(:request_instrument_name, nil),
                                                         cache_instrument_name: instrumentation.fetch(:cache_instrument_name, nil),
-                                                        server_cache_instrument_name: instrumentation.fetch(:server_cache_instrument_name, nil))
+                                                        server_cache_instrument_name: instrumentation.fetch(:server_cache_instrument_name, nil),
+                                                        faraday_config: faraday_config)
 
       @connection.basic_auth(username, password) if username && password
       @default_open_timeout = open_timeout
@@ -157,7 +159,8 @@ module RestfulResource
                               instrumenter: nil,
                               request_instrument_name: nil,
                               cache_instrument_name: nil,
-                              server_cache_instrument_name: nil)
+                              server_cache_instrument_name: nil,
+                              faraday_config: nil)
 
       @connection = Faraday.new do |b|
         b.request :json
@@ -181,6 +184,10 @@ module RestfulResource
 
         if instrumenter && request_instrument_name
           b.use :instrumentation, name: request_instrument_name
+        end
+
+        if faraday_config
+          faraday_config.call(b)
         end
 
         b.response :encoding

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -310,6 +310,32 @@ RSpec.describe RestfulResource::Base do
     end
   end
 
+  describe ".configure" do
+     let(:username) { double }
+     let(:password) { double }
+     let(:logger) { double }
+     let(:cache_store) { double }
+     let(:instrumentation) { double }
+     let(:faraday_config) { double }
+
+    it "passes arguments to HttpClient" do
+      expect(RestfulResource::HttpClient).to receive(:new).with(username: username,
+                                                                password: password,
+                                                                logger: logger,
+                                                                cache_store: cache_store,
+                                                                instrumentation: instrumentation,
+                                                                faraday_config: faraday_config)
+
+      RestfulResource::Base.configure(base_url: 'http://foo.bar',
+                                      username: username,
+                                      password: password,
+                                      logger: logger,
+                                      cache_store: cache_store,
+                                      instrumentation: instrumentation,
+                                      faraday_config: faraday_config)
+    end
+  end
+
   def response_with_page_information
     RestfulResource::Response.new(body: [{ id: 1, name: 'Golf'}, { id: 2, name: 'Polo' }].to_json,
                                  headers: { links: '<http://api.carwow.co.uk/makes/Volkswagen/models.json?page=6>;rel="last",<http://api.carwow.co.uk/makes/Volkswagen/models.json?page=2>;rel="next"'})

--- a/spec/restful_resource/http_client_configuration_spec.rb
+++ b/spec/restful_resource/http_client_configuration_spec.rb
@@ -137,6 +137,18 @@ describe RestfulResource::HttpClient do
           end
         end
       end
+
+      describe 'when provided a faraday config block' do
+        let(:faraday_config_block) do
+          proc { |conn| @block_arg = conn }
+        end
+        let(:connection) { described_class.new(faraday_config: faraday_config_block).instance_variable_get("@connection") }
+
+        it 'passes faraday connection instance and calls it' do
+          connection
+          expect(@block_arg.class).to eq(Faraday::Connection)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Allows adding custom configuration to faraday, for example adding new middlewares:

```ruby
MyClient::Base.configure(
  base_url: ENV['MY_API_PATH'],
  faraday_config: lambda { |conn| conn.use :my_custom_middleware }
)
```