### PR TITLE
Make API user agent explicit

### DIFF
--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -199,7 +199,8 @@ module RestfulResource
     end
 
     def build_user_agent(app_name)
-      parts = ["RestfulResource/#{VERSION}"]
+      parts = ["carwow/internal"]
+      parts << "RestfulResource/#{VERSION}"
       parts << "(#{app_name})" if app_name
       parts << "Faraday/#{Faraday::VERSION}"
       parts.join(' ')

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe RestfulResource::HttpClient do
 
     it 'sets a default user-agent header' do
       connection = faraday_connection do |stubs|
-        user_agent = "RestfulResource/#{RestfulResource::VERSION} Faraday/#{Faraday::VERSION}"
+        user_agent = "carwow/internal RestfulResource/#{RestfulResource::VERSION} Faraday/#{Faraday::VERSION}"
         stubs.get('http://httpbin.org/get', { 'User-Agent' => user_agent }) { |env| [200, {}, nil] }
       end
 
@@ -205,7 +205,7 @@ RSpec.describe RestfulResource::HttpClient do
 
     it 'sets a default user-agent header including app name' do
       connection = faraday_connection do |stubs|
-        user_agent = "RestfulResource/#{RestfulResource::VERSION} (my-app) Faraday/#{Faraday::VERSION}"
+        user_agent = "carwow/internal RestfulResource/#{RestfulResource::VERSION} (my-app) Faraday/#{Faraday::VERSION}"
         stubs.get('http://httpbin.org/get', { 'User-Agent' => user_agent }) { |env| [200, {}, nil] }
       end
 


### PR DESCRIPTION
https://carwow.atlassian.net/browse/UCL-202

We want to know how our current API's are used.
Part of this is knowing (tracking) which API endpoints are used by which apps/services - and more importantly which current API endpoints are just not being used!
To do this we can send a custom User-Agent along with each request that identifies the originator of the request.
The intention is to send this custom User-Agent to honeycomb.