### PR TITLE
Enhance API data collection

### DIFF
--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -122,7 +122,7 @@ module RestfulResource
     end
 
     def self.context_lambda
-      supperclass.instance_variable_get :@context_lambda
+      superclass.instance_variable_get :@context_lambda
     end
 
     private

--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -8,11 +8,11 @@ module RestfulResource
                        logger: nil,
                        cache_store: nil,
                        instrumentation: {},
+                       context_lambda: nil,
                        faraday_config: nil)
 
       @base_url = URI.parse(base_url)
-
-      @context_lambda = instrumentation.delete(:context_lambda)
+      @context_lambda = context_lambda
 
       @http = RestfulResource::HttpClient.new(username: username,
                                               password: password,

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -508,8 +508,6 @@ RSpec.describe RestfulResource::Base do
                                                                 instrumentation: instrumentation,
                                                                 faraday_config: faraday_config)
 
-      expect(instrumentation).to receive(:delete).with(:context_lambda)
-
       RestfulResource::Base.configure(base_url: 'http://foo.bar',
                                       username: username,
                                       password: password,

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -81,10 +81,9 @@ RSpec.describe RestfulResource::Base do
         RestfulResource::Response.new,
         headers: {
           cache_control: 'no-cache',
-          source_controller: 'SomeController',
-          source_action: 'index',
-          source_job: nil,
-          source_job_id: nil
+          source_type: 'controller',
+          source_class: 'SomeController',
+          source_identifier: 'index',
         }
       )
 
@@ -149,10 +148,9 @@ RSpec.describe RestfulResource::Base do
         RestfulResource::Response.new,
         headers: {
           cache_control: 'no-cache',
-          source_controller: 'SomeController',
-          source_action: 'index',
-          source_job: nil,
-          source_job_id: nil
+          source_type: 'controller',
+          source_class: 'SomeController',
+          source_identifier: 'index',
         }
       )
 
@@ -204,10 +202,9 @@ RSpec.describe RestfulResource::Base do
         RestfulResource::Response.new,
         headers: {
           cache_control: 'no-cache',
-          source_controller: 'SomeController',
-          source_action: 'index',
-          source_job: nil,
-          source_job_id: nil
+          source_type: 'controller',
+          source_class: 'SomeController',
+          source_identifier: 'index',
         }
       )
 
@@ -291,10 +288,9 @@ RSpec.describe RestfulResource::Base do
         RestfulResource::Response.new,
         headers: {
           cache_control: 'no-cache',
-          source_controller: 'SomeController',
-          source_action: 'index',
-          source_job: nil,
-          source_job_id: nil
+          source_type: 'controller',
+          source_class: 'SomeController',
+          source_identifier: 'index',
         }
       )
 
@@ -368,10 +364,9 @@ RSpec.describe RestfulResource::Base do
         RestfulResource::Response.new,
         headers: {
           accept: 'application/json',
-          source_controller: 'SomeController',
-          source_action: 'index',
-          source_job: nil,
-          source_job_id: nil
+          source_type: 'controller',
+          source_class: 'SomeController',
+          source_identifier: 'index',
         }
       )
 
@@ -417,10 +412,9 @@ RSpec.describe RestfulResource::Base do
         RestfulResource::Response.new,
         headers: {
           accept: 'application/json',
-          source_controller: 'SomeController',
-          source_action: 'index',
-          source_job: nil,
-          source_job_id: nil
+          source_type: 'controller',
+          source_class: 'SomeController',
+          source_identifier: 'index',
         }
       )
 
@@ -463,10 +457,9 @@ RSpec.describe RestfulResource::Base do
         RestfulResource::Response.new,
         headers: {
           accept: 'application/json',
-          source_controller: 'SomeController',
-          source_action: 'index',
-          source_job: nil,
-          source_job_id: nil
+          source_type: 'controller',
+          source_class: 'SomeController',
+          source_identifier: 'index',
         }
       )
 
@@ -536,13 +529,30 @@ RSpec.describe RestfulResource::Base do
     end
   end
 
+  describe ".context_headers" do
+    it "builds headers from keys in context_lambda starting with 'source_' only" do
+      a_lambda = context_lambda(
+        source_present: 'value',
+        random_key: 'should not be present'
+      )
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(a_lambda)
+
+      expect(RestfulResource::Base.context_headers).to eq(
+        source_type: 'controller',
+        source_class: 'SomeController',
+        source_identifier: 'index',
+        source_present: 'value'
+      )
+    end
+  end
+
   def context_lambda(args = {})
     lambda do
       {
-        source_controller: 'SomeController',
-        source_action: 'index',
-        source_job: nil,
-        source_job_id: nil
+        source_type: 'controller',
+        source_class: 'SomeController',
+        source_identifier: 'index',
       }.merge(args)
     end
   end

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -65,6 +65,33 @@ RSpec.describe RestfulResource::Base do
 
       Make.find(12, no_cache: true)
     end
+
+    it 'skips context headers when context_lambda is not set' do
+      expect_get("http://api.carwow.co.uk/makes/12",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(nil)
+
+      Make.find(12, no_cache: true)
+    end
+
+    it 'adds context headers when context_lambda is set' do
+      expect_get("http://api.carwow.co.uk/makes/12",
+        RestfulResource::Response.new,
+        headers: {
+          cache_control: 'no-cache',
+          source_controller: 'SomeController',
+          source_action: 'index',
+          source_job: nil,
+          source_job_id: nil
+        }
+      )
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(context_lambda).twice
+
+      Make.find(12, no_cache: true)
+    end
   end
 
   describe "#where" do
@@ -106,6 +133,33 @@ RSpec.describe RestfulResource::Base do
 
       Model.where(make_slug: 'Volkswagen', on_sale: true, group_id: 15, no_cache: true)
     end
+
+    it 'skips context headers when context_lambda is not set' do
+      expect_get("http://api.carwow.co.uk/groups/15/makes/Volkswagen/models?on_sale=true",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(nil)
+
+      Model.where(make_slug: 'Volkswagen', on_sale: true, group_id: 15, no_cache: true)
+    end
+
+    it 'adds context headers when context_lambda is set' do
+      expect_get("http://api.carwow.co.uk/groups/15/makes/Volkswagen/models?on_sale=true",
+        RestfulResource::Response.new,
+        headers: {
+          cache_control: 'no-cache',
+          source_controller: 'SomeController',
+          source_action: 'index',
+          source_job: nil,
+          source_job_id: nil
+        }
+      )
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(context_lambda).twice
+
+      Model.where(make_slug: 'Volkswagen', on_sale: true, group_id: 15, no_cache: true)
+    end
   end
 
   describe "#all" do
@@ -131,6 +185,33 @@ RSpec.describe RestfulResource::Base do
       expect_get("http://api.carwow.co.uk/makes",
         RestfulResource::Response.new,
         headers: { cache_control: 'no-cache' })
+
+      Make.all(no_cache: true)
+    end
+
+    it 'skips context headers when context_lambda is not set' do
+      expect_get("http://api.carwow.co.uk/makes",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(nil)
+
+      Make.all(no_cache: true)
+    end
+
+    it 'adds context headers when context_lambda is set' do
+      expect_get("http://api.carwow.co.uk/makes",
+        RestfulResource::Response.new,
+        headers: {
+          cache_control: 'no-cache',
+          source_controller: 'SomeController',
+          source_action: 'index',
+          source_job: nil,
+          source_job_id: nil
+        }
+      )
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(context_lambda).twice
 
       Make.all(no_cache: true)
     end
@@ -194,6 +275,33 @@ RSpec.describe RestfulResource::Base do
 
       Make.action(:average_score).get(no_cache: true)
     end
+
+    it 'skips context headers when context_lambda is not set' do
+      expect_get("http://api.carwow.co.uk/makes/average_score",
+        RestfulResource::Response.new,
+        headers: { cache_control: 'no-cache' })
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(nil)
+
+      Make.action(:average_score).get(no_cache: true)
+    end
+
+    it 'adds context headers when context_lambda is set' do
+      expect_get("http://api.carwow.co.uk/makes/average_score",
+        RestfulResource::Response.new,
+        headers: {
+          cache_control: 'no-cache',
+          source_controller: 'SomeController',
+          source_action: 'index',
+          source_job: nil,
+          source_job_id: nil
+        }
+      )
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(context_lambda).twice
+
+      Make.action(:average_score).get(no_cache: true)
+    end
   end
 
   describe "#put" do
@@ -244,6 +352,33 @@ RSpec.describe RestfulResource::Base do
 
       Make.put(1, data: {}, headers: { accept: 'application/json' })
     end
+
+    it 'skips context headers when context_lambda is not set' do
+      expect_put("http://api.carwow.co.uk/makes/1",
+        RestfulResource::Response.new,
+        headers: { accept: 'application/json' })
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(nil)
+
+      Make.put(1, data: {}, headers: { accept: 'application/json' })
+    end
+
+    it 'adds context headers when context_lambda is set' do
+      expect_put("http://api.carwow.co.uk/makes/1",
+        RestfulResource::Response.new,
+        headers: {
+          accept: 'application/json',
+          source_controller: 'SomeController',
+          source_action: 'index',
+          source_job: nil,
+          source_job_id: nil
+        }
+      )
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(context_lambda).twice
+
+      Make.put(1, data: {}, headers: { accept: 'application/json' })
+    end
   end
 
   describe "#post" do
@@ -266,6 +401,33 @@ RSpec.describe RestfulResource::Base do
 
       Make.post(data: {}, headers: { accept: 'application/json' })
     end
+
+    it 'skips context headers when context_lambda is not set' do
+      expect_post("http://api.carwow.co.uk/makes",
+        RestfulResource::Response.new,
+        headers: { accept: 'application/json' })
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(nil)
+
+      Make.post(data: {}, headers: { accept: 'application/json' })
+    end
+
+    it 'adds context headers when context_lambda is set' do
+      expect_post("http://api.carwow.co.uk/makes",
+        RestfulResource::Response.new,
+        headers: {
+          accept: 'application/json',
+          source_controller: 'SomeController',
+          source_action: 'index',
+          source_job: nil,
+          source_job_id: nil
+        }
+      )
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(context_lambda).twice
+
+      Make.post(data: {}, headers: { accept: 'application/json' })
+    end
   end
 
   describe "#delete" do
@@ -282,6 +444,33 @@ RSpec.describe RestfulResource::Base do
       expect_delete("http://api.carwow.co.uk/makes/1",
         RestfulResource::Response.new,
         headers: { accept: 'application/json' })
+
+      Make.delete(1, headers: { accept: 'application/json' })
+    end
+
+    it 'skips context headers when context_lambda is not set' do
+      expect_delete("http://api.carwow.co.uk/makes/1",
+        RestfulResource::Response.new,
+        headers: { accept: 'application/json' })
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(nil)
+
+      Make.delete(1, headers: { accept: 'application/json' })
+    end
+
+    it 'adds context headers when context_lambda is set' do
+      expect_delete("http://api.carwow.co.uk/makes/1",
+        RestfulResource::Response.new,
+        headers: {
+          accept: 'application/json',
+          source_controller: 'SomeController',
+          source_action: 'index',
+          source_job: nil,
+          source_job_id: nil
+        }
+      )
+
+      expect(RestfulResource::Base).to receive(:context_lambda).and_return(context_lambda).twice
 
       Make.delete(1, headers: { accept: 'application/json' })
     end
@@ -326,6 +515,8 @@ RSpec.describe RestfulResource::Base do
                                                                 instrumentation: instrumentation,
                                                                 faraday_config: faraday_config)
 
+      expect(instrumentation).to receive(:delete).with(:context_lambda)
+
       RestfulResource::Base.configure(base_url: 'http://foo.bar',
                                       username: username,
                                       password: password,
@@ -333,6 +524,26 @@ RSpec.describe RestfulResource::Base do
                                       cache_store: cache_store,
                                       instrumentation: instrumentation,
                                       faraday_config: faraday_config)
+    end
+
+    it "stores a lambda when it is defined" do
+      a_lambda = lambda { {context: 'info'} }
+
+      RestfulResource::Base.configure(base_url: 'http://foo.bar',
+                                      instrumentation: {context_lambda: a_lambda})
+
+      RestfulResource::Base.instance_variable_get(:@context_lambda).equal?(a_lambda)
+    end
+  end
+
+  def context_lambda(args = {})
+    lambda do
+      {
+        source_controller: 'SomeController',
+        source_action: 'index',
+        source_job: nil,
+        source_job_id: nil
+      }.merge(args)
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/6ycihDiw

We want to enhance data collected when we send a
request to our internal APIs.
To do this we append `SOURCE_*` headers to the request
so we can query them using honeycomb later.