### PR TITLE
Add Token auth option

### DIFF
--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -5,6 +5,7 @@ module RestfulResource
     def self.configure(base_url: nil,
                        username: nil,
                        password: nil,
+                       auth_token: nil,
                        logger: nil,
                        cache_store: nil,
                        instrumentation: {},
@@ -14,6 +15,7 @@ module RestfulResource
 
       @http = RestfulResource::HttpClient.new(username: username,
                                               password: password,
+                                              auth_token: auth_token,
                                               logger: logger,
                                               cache_store: cache_store,
                                               instrumentation: instrumentation,

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -70,6 +70,7 @@ module RestfulResource
 
     def initialize(username: nil,
                    password: nil,
+                   auth_token: nil,
                    logger: nil,
                    cache_store: nil,
                    connection: nil,
@@ -101,7 +102,12 @@ module RestfulResource
                                                         server_cache_instrument_name: instrumentation.fetch(:server_cache_instrument_name, nil),
                                                         faraday_config: faraday_config)
 
-      @connection.basic_auth(username, password) if username && password
+      if auth_token
+        @connection.headers[:authorization] = "Bearer #{auth_token}"
+      elsif username && password
+        @connection.basic_auth(username, password)
+      end
+
       @connection.headers[:user_agent] = build_user_agent(instrumentation[:app_name])
       @default_open_timeout = open_timeout
       @default_timeout = timeout

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -313,6 +313,7 @@ RSpec.describe RestfulResource::Base do
   describe ".configure" do
      let(:username) { double }
      let(:password) { double }
+     let(:auth_token) { double }
      let(:logger) { double }
      let(:cache_store) { double }
      let(:instrumentation) { double }
@@ -321,6 +322,7 @@ RSpec.describe RestfulResource::Base do
     it "passes arguments to HttpClient" do
       expect(RestfulResource::HttpClient).to receive(:new).with(username: username,
                                                                 password: password,
+                                                                auth_token: auth_token,
                                                                 logger: logger,
                                                                 cache_store: cache_store,
                                                                 instrumentation: instrumentation,
@@ -329,6 +331,7 @@ RSpec.describe RestfulResource::Base do
       RestfulResource::Base.configure(base_url: 'http://foo.bar',
                                       username: username,
                                       password: password,
+                                      auth_token: auth_token,
                                       logger: logger,
                                       cache_store: cache_store,
                                       instrumentation: instrumentation,

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -169,18 +169,36 @@ RSpec.describe RestfulResource::HttpClient do
   end
 
   describe 'Authentication' do
-    def http_client(connection)
-      described_class.new(connection: connection, username: 'user', password: 'passwd')
-    end
-
-    it 'should execute authenticated get' do
-      connection = faraday_connection do |stubs|
-        stubs.get('http://httpbin.org/basic-auth/user/passwd') { |env| [200, {}, nil] }
+    describe 'Basic auth' do
+      def http_client(connection)
+        described_class.new(connection: connection, username: 'user', password: 'passwd')
       end
 
-      response = http_client(connection).get('http://httpbin.org/basic-auth/user/passwd', headers: {"Authorization"=>"Basic dXNlcjpwYXNzd2Q="})
+      it 'should execute authenticated get' do
+        connection = faraday_connection do |stubs|
+          stubs.get('http://httpbin.org/basic-auth/user/passwd') { |env| [200, {}, nil] }
+        end
 
-      expect(response.status).to eq 200
+        response = http_client(connection).get('http://httpbin.org/basic-auth/user/passwd', headers: {"Authorization"=>"Basic dXNlcjpwYXNzd2Q="})
+
+        expect(response.status).to eq 200
+      end
+    end
+
+    describe 'Token auth' do
+      def http_client(connection)
+        described_class.new(connection: connection, auth_token: 'abc123')
+      end
+
+      it 'should execute authenticated get' do
+        connection = faraday_connection do |stubs|
+          stubs.get('http://httpbin.org/bearer', { 'Authorization' => 'Bearer abc123'} ) { |env| [200, {}, nil] }
+        end
+
+        response = http_client(connection).get('http://httpbin.org/bearer', headers: { 'Authorization' => 'Bearer abc123'})
+
+        expect(response.status).to eq 200
+      end
     end
   end
 


### PR DESCRIPTION
Add option to send Authorization: Bearer TOKEN header to authenticate requests, rather than basic auth.

Token auth will be used in preference to basic auth if both are supplied