### PR TITLE
Add X-Client-Timeout if connection/request timeout set

### DIFF
--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -126,7 +126,6 @@ module RestfulResource
       end
 
       @connection.headers[:user_agent] = build_user_agent(instrumentation[:app_name])
-      @connection.headers[:x_client_timeout] = @connection.options[:timeout] if @connection.options[:timeout]
     end
 
     def get(url, headers: {}, open_timeout: nil, timeout: nil)
@@ -254,6 +253,7 @@ module RestfulResource
         req.url request.url
 
         req.headers = req.headers.merge(request.headers)
+        req.headers = req.headers.merge(x_client_timeout: req.options[:timeout]) if req.options[:timeout]
       end
 
       Response.new(body: response.body, headers: response.headers, status: response.status)

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -126,6 +126,7 @@ module RestfulResource
       end
 
       @connection.headers[:user_agent] = build_user_agent(instrumentation[:app_name])
+      @connection.headers[:x_client_timeout] = @connection.options[:timeout] if @connection.options[:timeout]
     end
 
     def get(url, headers: {}, open_timeout: nil, timeout: nil)

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe RestfulResource::HttpClient do
     end
 
 
-    context 'when explicit timeout set' do
+    context 'when explicit timeout set on connection' do
       let(:timeout) { 5 }
       let(:required_headers) { { 'X-Client-Timeout' => 5 } }
       it 'sets X-Client-Timeout correctly' do
@@ -322,6 +322,17 @@ RSpec.describe RestfulResource::HttpClient do
 
       it 'sets X-Client-Timeout correctly' do
         response = http_client.get('http://httpbin.org/get')
+
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when set on request' do
+      let(:timeout) { nil }
+      let(:required_headers) { { 'X-Client-Timeout' => 1 } }
+
+      it 'sets X-Client-Timeout correctly' do
+        response = http_client.get('http://httpbin.org/get', timeout: 1)
 
         expect(response.status).to eq 200
       end


### PR DESCRIPTION
Add `X-Client-Timeout` on all resful-resource request if a timeout has been configured on the underlying faraday connection.

This should allow servers to decide whether it is worth processing a request when under load.
i.e. a server may choose not to process a request which has been waiting for processing longer than the client has set as a timeout.