### PR TITLE
Faraday 0.15.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-2.6.0
+2.6.1
+---
+- Support only `faraday-0.15.x`
+    - `0.16.x` breaks `faraday-http-cache`
+
+2.6.0 (yanked)
 ---
 
+- Upgrade to `faraday-0.16.x`
 - Add `X-Client-Timeout` header on requests if a client timeout is set
-
 
 2.5.3
 ---

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     restful_resource (2.6.0)
       activesupport
-      faraday (~> 0.16.0, > 0.16.1)
+      faraday (~> 0.15.0)
       faraday-cdn-metrics
       faraday-encoding
       faraday-http-cache
@@ -31,7 +31,7 @@ GEM
     diff-lcs (1.3)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    faraday (0.16.2)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cdn-metrics (0.1.0)
       faraday (~> 0.11)

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.6.1'.freeze
 end

--- a/restful_resource.gemspec
+++ b/restful_resource.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-its'
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'faraday', '~> 0.16.0', '> 0.16.1'
+  spec.add_dependency 'faraday', '~> 0.15.0'
   spec.add_dependency 'faraday-cdn-metrics'
   spec.add_dependency 'faraday-encoding'
   spec.add_dependency 'faraday-http-cache'

--- a/spec/restful_resource/http_client_configuration_spec.rb
+++ b/spec/restful_resource/http_client_configuration_spec.rb
@@ -19,7 +19,7 @@ describe RestfulResource::HttpClient do
 
     describe 'Builder configuration' do
       it 'uses the typhoeus adapter' do
-        expect(connection.adapter).to eq Faraday::Adapter::Typhoeus
+        expect(middleware).to include Faraday::Adapter::Typhoeus
       end
 
       it 'url_encodes requests' do


### PR DESCRIPTION
Release 2.6.1 version for faraday 0.15.x until plataformatec/faraday-http-cache#114 is resolved