### PR TITLE
Add X-Client-Start header

### DIFF
--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -252,7 +252,7 @@ module RestfulResource
         req.body = request.body unless request.body.nil?
         req.url request.url
 
-        req.headers = req.headers.merge(request.headers)
+        req.headers = req.headers.merge(request.headers).merge(x_client_start: time_current_ms)
         req.headers = req.headers.merge(x_client_timeout: req.options[:timeout]) if req.options[:timeout]
       end
 
@@ -281,6 +281,10 @@ module RestfulResource
       when 504 then raise HttpClient::GatewayTimeout.new(request, response)
       else raise HttpClient::OtherHttpError.new(request, response)
       end
+    end
+
+    def time_current_ms
+      (Time.current.to_f * 1_000.0).to_i
     end
   end
 end

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -266,8 +266,6 @@ module RestfulResource
       raise ClientError, request unless response
 
       handle_error(request, response)
-    rescue Faraday::ServerError => e
-      handle_error(request, e.response)
     end
 
     def handle_error(request, response)

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -338,4 +338,23 @@ RSpec.describe RestfulResource::HttpClient do
       end
     end
   end
+
+  describe 'X-Client-Start' do
+    let(:now) { Time.current }
+    let(:required_headers) { { 'X-Client-Start' => (now.to_f * 1000.0).to_i } }
+    let(:http_client) { described_class.new(connection: connection) }
+    let(:connection) do
+      conn = faraday_connection do |stubs|
+        stubs.get('http://httpbin.org/get', required_headers) { |_env| [200, {}, nil] }
+      end
+    end
+
+    before { allow(Time).to receive(:current).and_return(now) }
+
+    it 'sets X-Client-Start correctly' do
+      response = http_client.get('http://httpbin.org/get')
+
+      expect(response.status).to eq 200
+    end
+  end
 end


### PR DESCRIPTION
- Adds the current unix timestamp (ms) to request headers under `X-Client-Start`
- Removes `rescue` of `Faraday::ServerError` (doesn't exist in `faraday-0.15.x` 🤦‍♂ )