### PR TITLE
Add support for DELETE in RestfulResource::RailsValidations 

### DIFF
--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -58,7 +58,7 @@ module RestfulResource
     def self.delete(id, **params)
       params_without_options, options = format_params(params)
       response = http.delete(member_url(id, params_without_options), **options)
-      RestfulResource::OpenObject.new(parse_json(response.body))
+      new(parse_json(response.body))
     end
 
     def self.patch(id, data: {}, headers: {}, **params)

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -20,6 +20,12 @@ module RestfulResource
       end
     end
 
+    class BadRequest < HttpError
+      def message
+        'HTTP 400: Bad Request'
+      end
+    end
+
     class UnprocessableEntity < HttpError
     end
 
@@ -270,6 +276,7 @@ module RestfulResource
 
     def handle_error(request, response)
       case response[:status]
+      when 400 then raise HttpClient::BadRequest.new(request, response)
       when 404 then raise HttpClient::ResourceNotFound.new(request, response)
       when 409 then raise HttpClient::Conflict.new(request, response)
       when 422 then raise HttpClient::UnprocessableEntity.new(request, response)

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -20,12 +20,6 @@ module RestfulResource
       end
     end
 
-    class BadRequest < HttpError
-      def message
-        'HTTP 400: Bad Request'
-      end
-    end
-
     class UnprocessableEntity < HttpError
     end
 
@@ -276,7 +270,6 @@ module RestfulResource
 
     def handle_error(request, response)
       case response[:status]
-      when 400 then raise HttpClient::BadRequest.new(request, response)
       when 404 then raise HttpClient::ResourceNotFound.new(request, response)
       when 409 then raise HttpClient::Conflict.new(request, response)
       when 422 then raise HttpClient::UnprocessableEntity.new(request, response)

--- a/lib/restful_resource/rails_validations.rb
+++ b/lib/restful_resource/rails_validations.rb
@@ -17,13 +17,16 @@ module RestfulResource
         with_validations { super }
       end
 
+      def delete(*)
+        with_validations { super }
+      end
+
       private
 
       def with_validations(id = nil, data: {})
         yield
       rescue HttpClient::UnprocessableEntity => e
         errors = parse_json(e.response.body)
-        result = nil
         result = if errors.is_a?(Hash) && errors.key?('errors')
                    data.merge(errors)
                  else

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe RestfulResource::HttpClient do
     end
 
     shared_examples 'raise an exception on error responses' do |verb|
-      include_examples 'error codes throw exception', verb, 400, RestfulResource::HttpClient::BadRequest
       include_examples 'error codes throw exception', verb, 409, RestfulResource::HttpClient::Conflict
       include_examples 'error codes throw exception', verb, 404, RestfulResource::HttpClient::ResourceNotFound
       include_examples 'error codes throw exception', verb, 422, RestfulResource::HttpClient::UnprocessableEntity

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -16,175 +16,98 @@ RSpec.describe RestfulResource::HttpClient do
   end
 
   describe 'Basic HTTP' do
-    it 'executes get' do
-      connection = faraday_connection do |stubs|
-        stubs.get('http://httpbin.org/get') { |_env| [200, {}, nil] }
-      end
+    shared_examples 'error codes throw exception' do |verb, status, exception_class|
+      it "should raise an error #{status}" do
+        url = "http://httpbin.org/status/#{status}"
 
-      response = http_client(connection).get('http://httpbin.org/get')
-      expect(response.status).to eq 200
+        connection = faraday_connection do |stubs|
+          stubs.send(verb, url) { [status, {}, nil] }
+        end
+
+        expect { http_client(connection).send(verb, url) }.to raise_error(exception_class)
+      end
     end
 
-    it 'executes patch' do
-      connection = faraday_connection do |stubs|
-        # Note: request body is serialized as url-encoded so the stub body must be in the same format to match
-        stubs.patch('http://httpbin.org/patch', 'name=Alfred') { |_env| [200, {}, nil] }
-      end
+    shared_examples 'raise an exception on error responses' do |verb|
+      include_examples 'error codes throw exception', verb, 400, RestfulResource::HttpClient::BadRequest
+      include_examples 'error codes throw exception', verb, 409, RestfulResource::HttpClient::Conflict
+      include_examples 'error codes throw exception', verb, 404, RestfulResource::HttpClient::ResourceNotFound
+      include_examples 'error codes throw exception', verb, 422, RestfulResource::HttpClient::UnprocessableEntity
+      include_examples 'error codes throw exception', verb, 429, RestfulResource::HttpClient::TooManyRequests
+      include_examples 'error codes throw exception', verb, 502, RestfulResource::HttpClient::BadGateway
+      include_examples 'error codes throw exception', verb, 503, RestfulResource::HttpClient::ServiceUnavailable
+      include_examples 'error codes throw exception', verb, 504, RestfulResource::HttpClient::GatewayTimeout
 
-      response = http_client(connection).patch('http://httpbin.org/patch', data: { name: 'Alfred' })
-      expect(response.status).to eq 200
+      include_examples 'error codes throw exception', verb, 418, RestfulResource::HttpClient::OtherHttpError
     end
 
-    it 'executes put' do
-      connection = faraday_connection do |stubs|
-        # Note: request body is serialized as url-encoded so the stub body must be in the same format to match
-        stubs.put('http://httpbin.org/put', 'name=Alfred') { |_env| [200, {}, nil] }
-      end
+    context 'GET' do
+      include_examples 'raise an exception on error responses', :get
 
-      response = http_client(connection).put('http://httpbin.org/put', data: { name: 'Alfred' })
-      expect(response.status).to eq 200
+      it 'executes get' do
+        connection = faraday_connection do |stubs|
+          stubs.get('http://httpbin.org/get') { |_env| [200, {}, nil] }
+        end
+
+        response = http_client(connection).get('http://httpbin.org/get')
+        expect(response.status).to eq 200
+      end
     end
 
-    it 'executes post' do
-      connection = faraday_connection do |stubs|
-        # Note: request body is serialized as url-encoded so the stub body must be in the same format to match
-        stubs.post('http://httpbin.org/post', 'name=Alfred') { |_env| [200, {}, %("name": "Alfred")] }
+    context 'PATCH' do
+      include_examples 'raise an exception on error responses', :patch
+
+      it 'executes patch' do
+        connection = faraday_connection do |stubs|
+          # Note: request body is serialized as url-encoded so the stub body must be in the same format to match
+          stubs.patch('http://httpbin.org/patch', 'name=Alfred') { |_env| [200, {}, nil] }
+        end
+
+        response = http_client(connection).patch('http://httpbin.org/patch', data: { name: 'Alfred' })
+        expect(response.status).to eq 200
       end
-
-      response = http_client(connection).post('http://httpbin.org/post', data: { name: 'Alfred' })
-
-      expect(response.body).to include 'name": "Alfred'
-      expect(response.status).to eq 200
     end
 
-    it 'executes delete' do
-      connection = faraday_connection do |stubs|
-        stubs.delete('http://httpbin.org/delete') { |_env| [200, {}, nil] }
+    context 'PUT' do
+      include_examples 'raise an exception on error responses', :put
+      it 'executes put' do
+        connection = faraday_connection do |stubs|
+          # Note: request body is serialized as url-encoded so the stub body must be in the same format to match
+          stubs.put('http://httpbin.org/put', 'name=Alfred') { |_env| [200, {}, nil] }
+        end
+
+        response = http_client(connection).put('http://httpbin.org/put', data: { name: 'Alfred' })
+        expect(response.status).to eq 200
       end
-
-      response = http_client(connection).delete('http://httpbin.org/delete')
-
-      expect(response.status).to eq 200
     end
 
-    it 'patch should raise error 409' do
-      connection = faraday_connection do |stubs|
-        stubs.patch('http://httpbin.org/status/409') { |_env| [409, {}, nil] }
-      end
+    context 'POST' do
+      include_examples 'raise an exception on error responses', :post
+      it 'executes post' do
+        connection = faraday_connection do |stubs|
+          # Note: request body is serialized as url-encoded so the stub body must be in the same format to match
+          stubs.post('http://httpbin.org/post', 'name=Alfred') { |_env| [200, {}, %("name": "Alfred")] }
+        end
 
-      expect { http_client(connection).patch('http://httpbin.org/status/409') }.to raise_error(RestfulResource::HttpClient::Conflict)
+        response = http_client(connection).post('http://httpbin.org/post', data: { name: 'Alfred' })
+
+        expect(response.body).to include 'name": "Alfred'
+        expect(response.status).to eq 200
+      end
     end
 
-    it 'patch should raise error 422' do
-      connection = faraday_connection do |stubs|
-        stubs.patch('http://httpbin.org/status/422') { |_env| [422, {}, nil] }
+    context 'DELETE' do
+      include_examples 'raise an exception on error responses', :delete
+
+      it 'executes delete' do
+        connection = faraday_connection do |stubs|
+          stubs.delete('http://httpbin.org/delete') { |_env| [200, {}, nil] }
+        end
+
+        response = http_client(connection).delete('http://httpbin.org/delete')
+
+        expect(response.status).to eq 200
       end
-
-      expect { http_client(connection).patch('http://httpbin.org/status/422') }.to raise_error(RestfulResource::HttpClient::UnprocessableEntity)
-    end
-
-    it 'put should raise error 409' do
-      connection = faraday_connection do |stubs|
-        stubs.put('http://httpbin.org/status/409') { |_env| [409, {}, nil] }
-      end
-
-      expect { http_client(connection).put('http://httpbin.org/status/409') }.to raise_error(RestfulResource::HttpClient::Conflict)
-    end
-
-    it 'put should raise error 422' do
-      connection = faraday_connection do |stubs|
-        stubs.put('http://httpbin.org/status/422') { |_env| [422, {}, nil] }
-      end
-
-      expect { http_client(connection).put('http://httpbin.org/status/422') }.to raise_error(RestfulResource::HttpClient::UnprocessableEntity)
-    end
-
-    it 'post should raise error 422' do
-      connection = faraday_connection do |stubs|
-        stubs.post('http://httpbin.org/status/422') { |_env| [422, {}, nil] }
-      end
-
-      expect { http_client(connection).post('http://httpbin.org/status/422') }.to raise_error(RestfulResource::HttpClient::UnprocessableEntity)
-    end
-
-    it 'post should raise error 429' do
-      connection = faraday_connection do |stubs|
-        stubs.post('http://httpbin.org/status/429') { |_env| [429, {}, nil] }
-      end
-
-      expect { http_client(connection).post('http://httpbin.org/status/429') }.to raise_error(RestfulResource::HttpClient::TooManyRequests)
-    end
-
-    it 'patch should raise error 502' do
-      connection = faraday_connection do |stubs|
-        stubs.patch('http://httpbin.org/status/502') { |_env| [502, {}, nil] }
-      end
-
-      expect { http_client(connection).patch('http://httpbin.org/status/502') }.to raise_error(RestfulResource::HttpClient::BadGateway)
-    end
-
-    it 'put should raise error 502' do
-      connection = faraday_connection do |stubs|
-        stubs.put('http://httpbin.org/status/502') { |_env| [502, {}, nil] }
-      end
-
-      expect { http_client(connection).put('http://httpbin.org/status/502') }.to raise_error(RestfulResource::HttpClient::BadGateway)
-    end
-
-    it 'post should raise error 502' do
-      connection = faraday_connection do |stubs|
-        stubs.post('http://httpbin.org/status/502') { |_env| [502, {}, nil] }
-      end
-
-      expect { http_client(connection).post('http://httpbin.org/status/502') }.to raise_error(RestfulResource::HttpClient::BadGateway)
-    end
-
-    it 'patch should raise error 503' do
-      connection = faraday_connection do |stubs|
-        stubs.patch('http://httpbin.org/status/503') { |_env| [503, {}, nil] }
-      end
-
-      expect { http_client(connection).patch('http://httpbin.org/status/503') }.to raise_error(RestfulResource::HttpClient::ServiceUnavailable)
-    end
-
-    it 'put should raise error 503' do
-      connection = faraday_connection do |stubs|
-        stubs.put('http://httpbin.org/status/503') { |_env| [503, {}, nil] }
-      end
-
-      expect { http_client(connection).put('http://httpbin.org/status/503') }.to raise_error(RestfulResource::HttpClient::ServiceUnavailable)
-    end
-
-    it 'post should raise error 503' do
-      connection = faraday_connection do |stubs|
-        stubs.post('http://httpbin.org/status/503') { |_env| [503, {}, nil] }
-      end
-
-      expect { http_client(connection).post('http://httpbin.org/status/503') }.to raise_error(RestfulResource::HttpClient::ServiceUnavailable)
-    end
-
-    it 'post should raise error 504' do
-      connection = faraday_connection do |stubs|
-        stubs.post('http://httpbin.org/status/504') { |_env| [504, {}, nil] }
-      end
-
-      expect { http_client(connection).post('http://httpbin.org/status/504') }.to raise_error(RestfulResource::HttpClient::GatewayTimeout)
-    end
-
-    it 'raises error on 404' do
-      connection = faraday_connection do |stubs|
-        stubs.get('http://httpbin.org/status/404') { |_env| [404, {}, nil] }
-        stubs.post('http://httpbin.org/status/404') { |_env| [404, {}, nil] }
-        stubs.patch('http://httpbin.org/status/404') { |_env| [404, {}, nil] }
-        stubs.put('http://httpbin.org/status/404') { |_env| [404, {}, nil] }
-        stubs.delete('http://httpbin.org/status/404') { |_env| [404, {}, nil] }
-      end
-
-      expect { http_client(connection).get('http://httpbin.org/status/404') }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
-      expect { http_client(connection).delete('http://httpbin.org/status/404') }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
-      expect { http_client(connection).patch('http://httpbin.org/status/404', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
-      expect { http_client(connection).put('http://httpbin.org/status/404', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
-      expect { http_client(connection).post('http://httpbin.org/status/404', data: { name: 'Mad cow' }) }.to raise_error(RestfulResource::HttpClient::ResourceNotFound)
     end
 
     it 'raises Faraday::ConnectionFailed errors' do
@@ -209,14 +132,6 @@ RSpec.describe RestfulResource::HttpClient do
       end
 
       expect { http_client(connection).get('https://localhost:3005') }.to raise_error(RestfulResource::HttpClient::ClientError)
-    end
-
-    it 'raises OtherHttpError for other status response codes' do
-      connection = faraday_connection do |stubs|
-        stubs.get('http://httpbin.org/status/418') { |_env| [418, {}, nil] }
-      end
-
-      expect { http_client(connection).get('http://httpbin.org/status/418') }.to raise_error(RestfulResource::HttpClient::OtherHttpError)
     end
   end
 

--- a/spec/restful_resource/rails_validations_spec.rb
+++ b/spec/restful_resource/rails_validations_spec.rb
@@ -72,13 +72,13 @@ RSpec.describe RestfulResource::RailsValidations do
     end
   end
 
-  context '#patch without errors' do
+  context '#put without errors' do
     before do
       data = { name: 'Barak' }
       expected_response = RestfulResource::Response.new(body: { name: 'Barak' }.to_json)
-      expect_patch('http://api.carwow.co.uk/dealers/1', expected_response, data: data)
+      expect_put('http://api.carwow.co.uk/dealers/1', expected_response, data: data)
 
-      @object = Dealer.patch(1, data: data)
+      @object = Dealer.put(1, data: data)
     end
 
     it 'returns object' do
@@ -237,6 +237,55 @@ RSpec.describe RestfulResource::RailsValidations do
       @object = Dealer.get
       expect(@object).not_to be_valid
       expect(@object.errors).to eq @error
+    end
+  end
+
+  describe '#delete' do
+    subject { Dealer.delete(123) }
+
+    context 'without errors' do
+      before do
+        expected_response = RestfulResource::Response.new(body: { name: 'Barak' }.to_json)
+        expect_delete('http://api.carwow.co.uk/dealers/123', expected_response)
+      end
+
+      it 'returns object' do
+        expect(subject.name).to eq 'Barak'
+      end
+
+      it 'returns valid object' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'with errors' do
+      let(:errors) { { errors: ['Cannot use Ninja Turtles names'] } }
+
+      before do
+        expected_response = RestfulResource::Response.new(body: errors.to_json)
+        expect_delete_with_unprocessable_entity('http://api.carwow.co.uk/dealers/123', expected_response)
+      end
+
+      it 'has an error' do
+        expect(subject.errors.count).to eq 1
+      end
+
+      it 'has correct error' do
+        expect(subject.errors.first).to eq 'Cannot use Ninja Turtles names'
+      end
+
+      it 'returns not valid object' do
+        expect(subject).not_to be_valid
+      end
+
+      context 'when there is a single error' do
+        let(:errors) { 'Cannot use Ninja Turtles names' }
+
+        it 'handles errors returned as root object' do
+          expect(subject).not_to be_valid
+          expect(subject.errors).to eq errors
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,3 +65,10 @@ def expect_post_with_unprocessable_entity(url, response, data: {})
   exception = RestfulResource::HttpClient::UnprocessableEntity.new(request, rest_client_response)
   expect(@mock_http).to receive(:post).with(url, data: data, headers: {}, open_timeout: nil, timeout: nil).and_raise(exception)
 end
+
+def expect_delete_with_unprocessable_entity(url, response)
+  request = RestfulResource::Request.new(:delete, url)
+  rest_client_response = OpenStruct.new(body: response.body, headers: response.headers, code: response.status)
+  exception = RestfulResource::HttpClient::UnprocessableEntity.new(request, rest_client_response)
+  expect(@mock_http).to receive(:delete).with(url, headers: {}, open_timeout: nil, timeout: nil).and_raise(exception)
+end


### PR DESCRIPTION
This is something that bothers me a lot.

The other verbs were returning an object that responds to `valid?` or not, based on the response status.
Now `DELETE` returns that too.