### PR TITLE
Deprecate `:dig` and `:[]` first.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    restful_resource (2.11.0)
+    restful_resource (2.12.0)
       activesupport (~> 6.0)
       faraday (~> 1.0)
       faraday-cdn-metrics (~> 0.2)
@@ -15,7 +15,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3)
+    activesupport (6.1.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -44,12 +44,12 @@ GEM
     faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    ffi (1.14.2)
+    ffi (1.15.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     link_header (0.0.8)
     method_source (1.0.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     multipart-post (2.1.1)
     parallel (1.20.0)
     parser (2.7.2.0)

--- a/lib/restful_resource/strict_open_struct.rb
+++ b/lib/restful_resource/strict_open_struct.rb
@@ -1,5 +1,5 @@
 module RestfulResource
   class StrictOpenStruct < ::OpenStruct
-    undef_method :dig, :[]
+    deprecate :dig, :[]
   end
 end

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.11.0'.freeze
+  VERSION = '2.12.0'.freeze
 end


### PR DESCRIPTION
We recently removed these methods to prevent inner-object access of non-existent attributes via [] or dig (#110).
However, the change was disruptive for everyone's workflow and requires a lot of focus to migrate the api_clients, tests and services.

So I'm releasing a new _minor_ version to bring back these methods but deprecating the methods.
Then, when we want to move forward with a "stricter" version, we can configure the `disallowed_behavior` in Rails first to be ready for the migration.

This PR won't break any behaviour, in fact, it will unblock some dependabot PRs.