### PR TITLE
Bump ruby requirement to 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+2.13.0
+---
+
+- Require ruby >= 2.7
+
 2.10.0
 ---
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    restful_resource (2.12.1)
+    restful_resource (2.13.0)
       activesupport (~> 6.0)
       faraday (~> 1.0)
       faraday-cdn-metrics (~> 0.2)
@@ -15,7 +15,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.3.1)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -27,25 +27,39 @@ GEM
       rubocop-performance
       rubocop-rspec
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.4.4)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
-    faraday (1.3.0)
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
+    faraday (1.8.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
     faraday-cdn-metrics (0.2.0)
       faraday (~> 1)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-encoding (0.0.5)
       faraday
+    faraday-excon (1.1.0)
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
+    faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday_middleware (1.0.0)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    ffi (1.15.0)
-    i18n (1.8.10)
+    ffi (1.15.4)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     link_header (0.0.8)
     method_source (1.0.0)
@@ -98,13 +112,13 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.10.1)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
@@ -120,4 +134,4 @@ DEPENDENCIES
   rspec_junit_formatter
 
 BUNDLED WITH
-   2.1.4
+   2.2.30

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.12.1'.freeze
+  VERSION = '2.13.0'.freeze
 end

--- a/restful_resource.gemspec
+++ b/restful_resource.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'carwow_rubocop'


### PR DESCRIPTION
Rails 7 will require ruby 2.7 and rails 6 requires ruby 2.5. It would be good to bump the requirement here as it prevents some gems from being updated.