### PR TITLE
Update Changelog and version to 2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+2.13.1
+---
+
+- Update activesupport requirement from ~> 6.0 to >= 6, < 8 (#152)
+
 2.13.0
 ---
 

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.13.0'.freeze
+  VERSION = '2.13.1'.freeze
 end


### PR DESCRIPTION
Updating the version.rb and CHANGELOG to release a new version to update the activesupport requirement from `~> 6.0` to `>= 6, < 8`