### PR TITLE
Updated fetch all method for Ruby 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+2.13.2
+---
+
+- Added double splat operator to resolve failures when fetching data from other projects
+
 2.13.1
 ---
 

--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -110,7 +110,7 @@ module RestfulResource
       Enumerator.new do |y|
         next_page = 1
         begin
-          resources = where(conditions.merge(page: next_page))
+          resources = where(**conditions.merge(page: next_page))
           resources.each do |resource|
             y << resource
           end

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.13.1'.freeze
+  VERSION = '2.13.2'.freeze
 end


### PR DESCRIPTION
We are upgrading the Ruby version to 3.1 in flatmin. With any reference `fetchAll!`, an error is thrown. This PR sets to resolve this.