### PR TITLE
Add double splat operator to rails_validations file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+2.13.3
+---
+
+- Added double splat operator to resolve failures when fetching data from finance app
 
 2.13.2
 ---

--- a/lib/restful_resource/rails_validations.rb
+++ b/lib/restful_resource/rails_validations.rb
@@ -13,11 +13,11 @@ module RestfulResource
         with_validations(data: data) { super }
       end
 
-      def get(*)
+      def get(**)
         with_validations { super }
       end
 
-      def delete(*)
+      def delete(id, **)
         with_validations { super }
       end
 

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.13.2'.freeze
+  VERSION = '2.13.3'.freeze
 end


### PR DESCRIPTION
As part of the migration to ruby 3.1 in the finance app we need to manage some method calls adding double splat operators