### PR TITLE
Fix Ruby 3 deprecation warning

### DIFF
--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -51,7 +51,7 @@ module RestfulResource
     def self.get(**params)
       params_without_options, options = format_params(**params)
 
-      response = http.get(collection_url(**params_without_options), **options)
+      response = http.get(collection_url(params_without_options), **options)
       new(parse_json(response.body))
     end
 
@@ -85,7 +85,7 @@ module RestfulResource
       params_without_options, options = format_params(**params)
       options.delete(:headers)
 
-      url = collection_url(**params_without_options)
+      url = collection_url(params_without_options)
 
       response = http.post(url, data: data, headers: headers, **options)
 


### PR DESCRIPTION
The last deprecation warnings in dealers site all point to line 88 of base.rb file in this gem, where we were calling a double splat on `params_without_options`. We were getting the following error warnings:

```
DEPRECATION WARNING: /app/vendor/bundle/ruby/2.7.0/gems/restful_resource-2.13.3/lib/restful_resource/base.rb:88: warning: Passing the keyword argument as the last hash parameter is deprecated
 (called from block (2 levels) in deliver at /app/app/mailers/iterable_mailer.rb:32)
 
DEPRECATION WARNING: /app/vendor/bundle/ruby/2.7.0/gems/restful_resource-2.13.3/lib/restful_resource/base.rb:88: warning: Passing the keyword argument as the last hash parameter is deprecated
 (called from perform at /app/app/jobs/iterable_events/user_cancelled_sale.rb:23)

DEPRECATION WARNING: /app/vendor/bundle/ruby/2.7.0/gems/restful_resource-2.13.3/lib/restful_resource/base.rb:88: warning: Passing the keyword argument as the last hash parameter is deprecated
 (called from perform at /app/app/jobs/iterable_events/quote_listing_outbid.rb:15)

DEPRECATION WARNING: /app/vendor/bundle/ruby/2.7.0/gems/restful_resource-2.13.3/lib/restful_resource/base.rb:88: warning: Passing the keyword argument as the last hash parameter is deprecated
 (called from perform at /app/app/jobs/iterable_events/dealer_submitted_quote.rb:15)
```

It appears that this was changed as part of a blanket Ruby 2.7 deprecations list back in 2020 but in this instance I think the change was not necessary as `collection_url(**params)` expects a hash of params rather than keyword args.

In the instance of the collection_url method, we are often calling it with an empty hash, which is when we get the deprecation warning. If we call the method with a hash with some content there is no deprecation warning. The behaviour is further explained in the [ruby lang docs](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#other-minor-changes-empty-hash). 

I believe that removing the double splat from the call to collection_url will fix the deprecation warnings while keeping the behaviour as intended. I've also fixed the same call in 2 other places in the same file.