### PR TITLE
Support constructing http client error from another error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-2.14.0
+2.13.4
 ---
 
 - Support passing a an instance of `RestfulResource::Response` to the constructor for a `RestfulResource::HttpClient::HttpError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+2.14.0
+---
+
+- Support passing a an instance of `RestfulResource::Response` to the constructor for a `RestfulResource::HttpClient::HttpError`
+
 2.13.3
 ---
 

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -11,8 +11,12 @@ module RestfulResource
         @response = assign_response(response)
       end
 
-      def assign_response(response = nil)
-        @response = if response
+      private
+
+      def assign_response(response)
+        @response = if response.is_a?(Response)
+                      response
+                    elsif response
                       Response.new(body: response[:body], headers: response[:headers], status: response[:status])
                     else
                       Response.new

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.13.3'.freeze
+  VERSION = '2.14.0'.freeze
 end

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.14.0'.freeze
+  VERSION = '2.13.4'.freeze
 end


### PR DESCRIPTION
In reference to this discussion: https://github.com/carwow/research_site/pull/13625/files#r1122866223

For a custom subclass of the `RestfulResource::HttpClient::HttpError` (e.g. the linked example, where we also want to store a `make_slug` and `model_slug` as attributes), we're like a way to construct the object by calling `super`. This means the parent class initializer needs to support an existing `Response` object, instead of assuming the `response` object is a `Hash`.