### PR TITLE
[T-WRECKS] Add options to configure default headers

### DIFF
--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -12,7 +12,9 @@ module RestfulResource
       timeout: nil,
       open_timeout: nil,
       faraday_config: nil,
-      faraday_options: {})
+      faraday_options: {},
+      default_headers: {}
+    )
 
       @base_url = URI.parse(base_url)
 
@@ -25,7 +27,8 @@ module RestfulResource
                                               open_timeout: open_timeout,
                                               instrumentation: instrumentation,
                                               faraday_config: faraday_config,
-                                              faraday_options: faraday_options
+                                              faraday_options: faraday_options,
+                                              default_headers: default_headers
                                              )
     end
 

--- a/lib/restful_resource/http_client.rb
+++ b/lib/restful_resource/http_client.rb
@@ -92,7 +92,9 @@ module RestfulResource
       timeout: nil,
       open_timeout: nil,
       faraday_config: nil,
-      faraday_options: {})
+      faraday_options: {},
+      default_headers: {}
+    )
       api_name = instrumentation[:api_name]            ||= 'api'
       instrumentation[:request_instrument_name]        ||= "http.#{api_name}"
       instrumentation[:cache_instrument_name]          ||= "http_cache.#{api_name}"
@@ -122,6 +124,8 @@ module RestfulResource
                                                         faraday_config: faraday_config,
                                                         faraday_options: faraday_options
                                                        )
+
+      @connection.headers.merge!(default_headers)
 
       if auth_token
         @connection.headers[:authorization] = "Bearer #{auth_token}"

--- a/spec/restful_resource/base_spec.rb
+++ b/spec/restful_resource/base_spec.rb
@@ -390,33 +390,38 @@ RSpec.describe RestfulResource::Base do
     let(:open_timeout) { double }
     let(:faraday_config) { double }
     let(:faraday_options) { double }
+    let(:default_headers) { double }
 
     it 'passes arguments to HttpClient' do
       client = Class.new(described_class)
-      expect(RestfulResource::HttpClient).to receive(:new).with(username: username,
-                                                                password: password,
-                                                                auth_token: auth_token,
-                                                                logger: logger,
-                                                                cache_store: cache_store,
-                                                                instrumentation: instrumentation,
-                                                                timeout: timeout,
-                                                                open_timeout: open_timeout,
-                                                                faraday_config: faraday_config,
-                                                                faraday_options: faraday_options
-                                                               )
+      expect(RestfulResource::HttpClient).to receive(:new).with(
+        username: username,
+        password: password,
+        auth_token: auth_token,
+        logger: logger,
+        cache_store: cache_store,
+        instrumentation: instrumentation,
+        timeout: timeout,
+        open_timeout: open_timeout,
+        faraday_config: faraday_config,
+        faraday_options: faraday_options,
+        default_headers: default_headers
+      )
 
-      client.configure(base_url: 'http://foo.bar',
-                       username: username,
-                       password: password,
-                       auth_token: auth_token,
-                       logger: logger,
-                       cache_store: cache_store,
-                       instrumentation: instrumentation,
-                       timeout: timeout,
-                       open_timeout: open_timeout,
-                       faraday_config: faraday_config,
-                       faraday_options: faraday_options
-                      )
+      client.configure(
+        base_url: 'http://foo.bar',
+        username: username,
+        password: password,
+        auth_token: auth_token,
+        logger: logger,
+        cache_store: cache_store,
+        instrumentation: instrumentation,
+        timeout: timeout,
+        open_timeout: open_timeout,
+        faraday_config: faraday_config,
+        faraday_options: faraday_options,
+        default_headers: default_headers
+      )
     end
   end
 

--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -271,4 +271,16 @@ RSpec.describe RestfulResource::HttpClient do
       expect(response.status).to eq 200
     end
   end
+
+  describe 'default headers' do
+    it 'uses default headers' do
+      connection = faraday_connection do |stubs|
+        stubs.get('http://httpbin.org/get', 'Foo' => 'bar') { |_env| [200, {}, nil] }
+      end
+
+      response = described_class.new(connection: connection, default_headers: { foo: 'bar' }).get('http://httpbin.org/get')
+
+      expect(response.status).to eq 200
+    end
+  end
 end


### PR DESCRIPTION
By adding a `default_headers` configuration one can configure a `RestfulResource` object with default headers like an API key. This will be used by the `iterable_api_client` to pass the API key as a default header to all requests.  

Card: https://carwow.kanbanize.com/ctrl_board/87/cards/71100/