### PR TITLE
TI-74373  ⬆️   Bump `faraday` to a minimum `1.10`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+2.15
+---
+
+- Bump `faraday` to a minimum of `1.10` to resolve dependency issues
+
 2.14
 ---
 

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.14.0'.freeze
+  VERSION = '2.15.0'.freeze
 end

--- a/restful_resource.gemspec
+++ b/restful_resource.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
 
   spec.add_dependency 'activesupport', '>= 6', '< 8'
-  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 1.10'
   spec.add_dependency 'faraday-cdn-metrics', '~> 0.2'
   spec.add_dependency 'faraday-encoding'
   spec.add_dependency 'faraday-http-cache', '~> 2.2'


### PR DESCRIPTION
### Description
Does what it says on the tin.

The reason for this bump is that @Zeneixe and I think that this dependabot PR:
https://github.com/carwow/research_site/pull/15129/files
is downgrading the `faraday` dependency from `1.10` -> `1.9` due to the chain of dependencies:

`research_site` -> [cms_client](https://github.com/carwow/cms_site_api_client/blob/master/cms_site_api_client.gemspec) -> this gem.

If we enforce the higher version the de-bump should disappear.