### PR TITLE
Re-add deprecator for :dig and :[] methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+2.17
+---
+
+- Re-add deprecation for :dig and :[] since they are still used by some clients
+
 2.16
 ---
 

--- a/lib/restful_resource.rb
+++ b/lib/restful_resource.rb
@@ -24,3 +24,4 @@ require_relative 'restful_resource/redirections'
 require_relative 'restful_resource/instrumentation'
 require_relative 'restful_resource/base'
 require_relative 'restful_resource/strict_open_struct'
+require_relative 'restful_resource/railtie' if defined?(Rails::Railtie)

--- a/lib/restful_resource/base.rb
+++ b/lib/restful_resource/base.rb
@@ -2,6 +2,8 @@ module RestfulResource
   class Base < OpenObject
     extend RestfulResource::Associations
 
+    Deprecator = ActiveSupport::Deprecation.new('soon', 'restful_resource')
+
     def self.configure(base_url: nil,
       username: nil,
       password: nil,

--- a/lib/restful_resource/railtie.rb
+++ b/lib/restful_resource/railtie.rb
@@ -1,6 +1,6 @@
 module RestfulResource
   class Railtie < Rails::Railtie
-    initializer "restful_resource.deprecator" do |app|
+    initializer 'restful_resource.deprecator' do |app|
       app.deprecators[:restful_resource] = Base::Deprecator
     end
   end

--- a/lib/restful_resource/railtie.rb
+++ b/lib/restful_resource/railtie.rb
@@ -1,0 +1,7 @@
+module RestfulResource
+  class Railtie < Rails::Railtie
+    initializer "restful_resource.deprecator" do |app|
+      app.deprecators[:restful_resource] = Base::Deprecator
+    end
+  end
+end

--- a/lib/restful_resource/strict_open_struct.rb
+++ b/lib/restful_resource/strict_open_struct.rb
@@ -1,5 +1,5 @@
 module RestfulResource
   class StrictOpenStruct < ::OpenStruct
-    undef_method :dig, :[]
+    deprecate :dig, :[], deprecator: Base::Deprecator
   end
 end

--- a/lib/restful_resource/version.rb
+++ b/lib/restful_resource/version.rb
@@ -1,3 +1,3 @@
 module RestfulResource
-  VERSION = '2.16.0'.freeze
+  VERSION = '2.17.0'.freeze
 end

--- a/spec/restful_resource/strict_open_struct_spec.rb
+++ b/spec/restful_resource/strict_open_struct_spec.rb
@@ -4,14 +4,18 @@ RSpec.describe RestfulResource::StrictOpenStruct do
   let(:instance) { described_class.new(foo: 'bar') }
 
   describe '#dig' do
-    it 'is not defined' do
-      expect { instance.dig(:foo) }.to raise_error(NoMethodError)
+    it 'is deprecated' do
+      expect { instance.dig(:foo) }.to output(
+        /dig is deprecated and will be removed from restful_resource soon/
+      ).to_stderr
     end
   end
 
   describe '#[]' do
-    it 'is not defined' do
-      expect { instance[:foo] }.to raise_error(NoMethodError)
+    it 'is deprecated' do
+      expect { instance[:foo] }.to output(
+        /\[\] is deprecated and will be removed from restful_resource soon/
+      ).to_stderr
     end
   end
 end


### PR DESCRIPTION
It looks like quotes site still uses these methods. We decided to remove them because honeycomb didn't report any usage of them but it looks like something was broken because they are still used. More details [here](https://github.com/carwow/quotes_site/pull/24992#discussion_r1512911963).

This PR re-adds a deprecator but following the new convention.