### PR TITLE
Add explicit test for custom auth header

### DIFF
--- a/spec/restful_resource/http_client_spec.rb
+++ b/spec/restful_resource/http_client_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe RestfulResource::HttpClient do
     end
 
     describe 'Token auth' do
-      def http_client(connection)
+      def http_client_with_auth(connection)
         described_class.new(connection: connection, auth_token: 'abc123')
       end
 
@@ -161,7 +161,17 @@ RSpec.describe RestfulResource::HttpClient do
           stubs.get('http://httpbin.org/bearer', 'Authorization' => 'Bearer abc123') { |_env| [200, {}, nil] }
         end
 
-        response = http_client(connection).get('http://httpbin.org/bearer', headers: { 'Authorization' => 'Bearer abc123' })
+        response = http_client_with_auth(connection).get('http://httpbin.org/bearer')
+
+        expect(response.status).to eq 200
+      end
+
+      it 'overrides authentication headers when a custom authentication header is passed in' do
+        connection = faraday_connection do |stubs|
+          stubs.get('http://httpbin.org/bearer', 'Authorization' => 'Bearer my-custom-header') { |_env| [200, {}, nil] }
+        end
+
+        response = http_client_with_auth(connection).get('http://httpbin.org/bearer', headers: { 'Authorization' => 'Bearer my-custom-header' })
 
         expect(response.status).to eq 200
       end


### PR DESCRIPTION
The behaviour is defined here: https://github.com/carwow/restful_resource/blob/561a7d250012dbd248307799f73b475c40c4dbbb/lib/restful_resource/http_client.rb#L260

But it seems we didn't have an explicit test to ensure custom authentication headers where overriding the header set in the initialisation:
https://github.com/carwow/restful_resource/blob/561a7d250012dbd248307799f73b475c40c4dbbb/lib/restful_resource/http_client.rb#L128
